### PR TITLE
chore: add module to avoid relative imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
     },
   },
   parser: '@typescript-eslint/parser',
-  plugins: ['react-refresh', 'sort-destructure-keys'],
+  plugins: ['react-refresh', 'sort-destructure-keys', 'no-relative-import-paths'],
   rules: {
     'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     'import/order': [
@@ -63,5 +63,9 @@ module.exports = {
     'react/jsx-uses-react': 'off',
     'react/no-unescaped-entities': 'off',
     'sort-destructure-keys/sort-destructure-keys': 'error',
+    'no-relative-import-paths/no-relative-import-paths': [
+      'error',
+      { allowSameFolder: false, prefix: '@' },
+    ],
   },
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-no-relative-import-paths": "^1.5.4",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ devDependencies:
   eslint-plugin-jsx-a11y:
     specifier: ^6.8.0
     version: 6.8.0(eslint@8.57.0)
+  eslint-plugin-no-relative-import-paths:
+    specifier: ^1.5.4
+    version: 1.5.4
   eslint-plugin-react:
     specifier: ^7.34.1
     version: 7.34.1(eslint@8.57.0)
@@ -5518,6 +5521,10 @@ packages:
       minimatch: 3.1.2
       object.entries: 1.1.8
       object.fromentries: 2.0.8
+    dev: true
+
+  /eslint-plugin-no-relative-import-paths@1.5.4:
+    resolution: {integrity: sha512-2smViH7R3682NR6dwgYr8Vm7emqNP1gEjBku6DbvUy3Ef/2Fz+mhwsFjZGSixzWzazMCj4MAgIWTsHELCCDJKA==}
     dev: true
 
   /eslint-plugin-react-hooks@4.6.2(eslint@8.57.0):

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,9 @@ import React from 'react'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import ReactDOM from 'react-dom/client'
 
-import { routeTree } from './routeTree.gen'
+import { routeTree } from '@/src/routeTree.gen'
 
-import './index.css'
+import '@/src/index.css'
 
 const router = createRouter({ routeTree })
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,7 +9,7 @@ import { TanStackReactQueryDevtools } from '@/src/_components/TanStackReactQuery
 import { TanStackRouterDevtools } from '@/src/_components/TanStackRouterDevtools'
 import { config } from '@/src/_lib/wagmi.config'
 
-import './__root.css'
+import '@/src/routes/__root.css'
 
 export const Route = createRootRoute({
   component: Root,


### PR DESCRIPTION
Closes #71

# Description:

Relative imports should be changed to their equivalent absolute imports when `pnpm lint:fix`ing, saving, or committing (thanks to `lint-staged`)

There shouldn't be any relative imports to be found in the current app.

# Steps:

- Import a component using a relative path.
- Save (it should fix on save if you're using an appropriately configured IDE like VS Code).
- If the last step didn't work, try the same with `pnpm lint:fix` in the console...
- ... or you could just commit your changes and `lint-staged` will do its thing and fix all the staged files.

## Type of change:

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [ ] Refactoring
- [x] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)
