### PR TITLE
fix: Return type of reactSuspenseRead plugin

### DIFF
--- a/src/lib/wagmi/plugins/reactSuspenseRead.ts
+++ b/src/lib/wagmi/plugins/reactSuspenseRead.ts
@@ -56,8 +56,8 @@ export function reactSuspenseRead(config: ActionsConfig = {}): ActionsResult {
             content.push(
               `
                 export const ${hookName} = ${pure} ${functionName}({ ${innerContent}, functionName: '${item.name}' })
-                export const useSuspense${pascalCase(hookName)} = (params: Parameters<typeof ${hookName}>[1], options?: UseSuspenseQueryOptions) => {
-                  return useSuspenseQuery({ queryKey: ['${hookName}', params, config.state.chainId], queryFn: () => ${hookName}(config, params), ...options })
+                export const useSuspense${pascalCase(hookName)} = (params: Parameters<typeof ${hookName}>[1], options?: UseSuspenseQueryOptions<Awaited<ReturnType<typeof ${hookName}>>>) => {
+                  return useSuspenseQuery<Awaited<ReturnType<typeof ${hookName}>>>({ queryKey: ['${hookName}', params, config.state.chainId], queryFn: () => ${hookName}(config, params), ...options })
                 }
               `,
             )


### PR DESCRIPTION
Closes #167

# Description:

Fix the return type of the auto-generated hooks with suspense.

# Steps:

(Required steps to reproduce or test the fix / feature)

## Type of change:

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [ ] Refactoring
- [ ] Chore

# How Has This Been Tested?

- [ ] Manual testing
- [ ] Automated tests
- [ ] Other (explain)

# Remember to check that:

- Your code follows the style guidelines of this project
- You have performed a self-review of your code
- You have commented your code in hard-to-understand areas
- You have made corresponding changes to the documentation
- Your changes generate no new warnings

# Screenshots
Before the fix:
<img width="1022" alt="image" src="https://github.com/BootNodeDev/dAppBooster/assets/33560821/48275ae8-8094-4d78-a506-d67125fc922f">

After the fix:
<img width="1022" alt="image" src="https://github.com/BootNodeDev/dAppBooster/assets/33560821/1110ee5d-1edc-4224-ae9b-beebe2346af4">