### PR TITLE
feat: prevent automatic docs creation

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -2,10 +2,6 @@
 name: TSDoc Actions
 
 on:
-  pull_request:
-    branches:
-      - main
-  release:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
# Description:

Currently, all the PRs are building a new version of the docs.

This is a change to have better control and only trigger doc building manually, on demand.

Later we can update it to build on a release or tag, or whatever condition we need.

## Type of change:

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [ ] Refactoring
- [x] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)

# Remember to check that:

- Your code follows the style guidelines of this project
- You have performed a self-review of your code
- You have commented your code in hard-to-understand areas
- You have made corresponding changes to the documentation
- Your changes generate no new warnings

# Screenshots

(Add screenshots or videos to help test this pull request)
