### PR TITLE
chore: add missing link to docs button

### DIFF
--- a/src/pageComponents/home/Welcome/DocsButton.tsx
+++ b/src/pageComponents/home/Welcome/DocsButton.tsx
@@ -20,7 +20,7 @@ const DocsButton = ({ ...restProps }) => {
   return (
     <Wrapper
       as="a"
-      href="https://github.com/BootNodeDev/dAppBooster#dappster"
+      href="https://bootnodedev.github.io/dAppBooster/"
       target="_blank"
       {...restProps}
     >


### PR DESCRIPTION
# Description:

Added a link to https://bootnodedev.github.io/dAppBooster/ to the Docs button.

# Steps:

Click the button and it should open a tab to https://bootnodedev.github.io/dAppBooster/

## Type of change:

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [ ] Refactoring
- [x] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)

# Remember to check that:

- Your code follows the style guidelines of this project
- You have performed a self-review of your code
- You have commented your code in hard-to-understand areas
- You have made corresponding changes to the documentation
- Your changes generate no new warnings

# Screenshots

![giphy](https://github.com/user-attachments/assets/59078b3d-7712-4433-a0f6-0debbe435f57)