### PR TITLE
fix: native token verification

### DIFF
--- a/src/hooks/useErc20Balance.ts
+++ b/src/hooks/useErc20Balance.ts
@@ -25,7 +25,7 @@ export const useErc20Balance = ({
   address?: Address
   token?: Token
 }): Erc20Balance => {
-  const enabled = !!address && !!token && isNativeToken(token.address)
+  const enabled = !!address && !!token && !isNativeToken(token.address)
 
   const { data, error, isLoading } = useReadContract({
     abi: erc20Abi,


### PR DESCRIPTION
# Description:

A problematic bug prevented the balance from properly loading when an ERC20 token was selected.

It required a thorough code review, intense debugging sessions, and liters of coffee and mate, but finally, I managed to tame the beast and fix this really ugly, hard-to-find bug.

# Steps:
Check the balance of an ERC20 token after selecting it in the list. It should be displayed next to the `max` button.

## Type of change:

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [ ] Refactoring
- [ ] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)

# Remember to check that:

- Your code follows the style guidelines of this project
- You have performed a self-review of your code
- You have commented your code in hard-to-understand areas
- You have made corresponding changes to the documentation
- Your changes generate no new warnings

# Screenshots
