### PR TITLE
refactor(TokenInput): remove flag

### DIFF
--- a/src/components/sharedComponents/TokenInput/index.tsx
+++ b/src/components/sharedComponents/TokenInput/index.tsx
@@ -47,12 +47,11 @@ export const CloseButton = styled(BaseCloseButton)`
 `
 
 interface TokenInputProps extends Omit<TokenSelectProps, 'onError'> {
-  singleToken?: boolean
-  token?: Token
   onAmountSet: (amount?: string) => void
   onError: (error?: string) => void
   thousandSeparator?: boolean
   title?: string
+  singleToken?: Token
 }
 
 /**
@@ -64,6 +63,7 @@ interface TokenInputProps extends Omit<TokenSelectProps, 'onError'> {
  * @param {(error?: string) => void} props.onError - A callback function triggered when there is an error.
  * @param {boolean} [props.thousandSeparator=true] - Optional flag to enable thousands separator. Default is true.
  * @param {string} props.title - The title of the token input.
+ * @param {Token} [props.singleToken] - The unique token to be displayed. Default is undefined.
  * @param {number} [props.currentNetworkId=mainnet.id] - The current network id. Default is mainnet's id.
  * @param {function} props.onTokenSelect - Callback function to be called when a token is selected.
  * @param {Networks} [props.networks] - Optional list of networks to display in the dropdown. The dropdown won't show up if undefined. Default is undefined.
@@ -143,7 +143,6 @@ const TokenInput: FC<TokenInputProps> = ({
   singleToken,
   thousandSeparator = true,
   title,
-  token,
   ...restProps
 }) => {
   const {
@@ -156,7 +155,7 @@ const TokenInput: FC<TokenInputProps> = ({
     setAmount,
     setAmountError,
     setTokenSelected,
-  } = useTokenInput(token)
+  } = useTokenInput(singleToken)
   const { Dialog, close, open } = useDialog()
   const max = useMemo(
     () => (balance && selectedToken ? formatUnits(balance, selectedToken.decimals) : '0'),
@@ -192,10 +191,6 @@ const TokenInput: FC<TokenInputProps> = ({
   const selectIconSize = 24
   const decimals = selectedToken ? selectedToken.decimals : 2
 
-  if (singleToken && !token) {
-    return <div>When single token is true, a token is required.</div>
-  }
-
   return (
     <>
       <Wrapper {...restProps}>
@@ -217,7 +212,7 @@ const TokenInput: FC<TokenInputProps> = ({
             )}
             value={amount}
           />
-          <DropdownButton onClick={showTokenSelect} singleOption={singleToken}>
+          <DropdownButton onClick={showTokenSelect} singleOption={!!singleToken}>
             {selectedToken ? (
               <>
                 <Icon $iconSize={selectIconSize}>

--- a/src/components/sharedComponents/TokenInput/index.tsx
+++ b/src/components/sharedComponents/TokenInput/index.tsx
@@ -47,11 +47,12 @@ export const CloseButton = styled(BaseCloseButton)`
 `
 
 interface TokenInputProps extends Omit<TokenSelectProps, 'onError'> {
+  singleToken?: boolean
+  token?: Token
   onAmountSet: (amount?: string) => void
   onError: (error?: string) => void
   thousandSeparator?: boolean
   title?: string
-  singleToken?: Token
 }
 
 /**
@@ -63,7 +64,6 @@ interface TokenInputProps extends Omit<TokenSelectProps, 'onError'> {
  * @param {(error?: string) => void} props.onError - A callback function triggered when there is an error.
  * @param {boolean} [props.thousandSeparator=true] - Optional flag to enable thousands separator. Default is true.
  * @param {string} props.title - The title of the token input.
- * @param {Token} [props.singleToken] - The unique token to be displayed. Default is undefined.
  * @param {number} [props.currentNetworkId=mainnet.id] - The current network id. Default is mainnet's id.
  * @param {function} props.onTokenSelect - Callback function to be called when a token is selected.
  * @param {Networks} [props.networks] - Optional list of networks to display in the dropdown. The dropdown won't show up if undefined. Default is undefined.
@@ -143,6 +143,7 @@ const TokenInput: FC<TokenInputProps> = ({
   singleToken,
   thousandSeparator = true,
   title,
+  token,
   ...restProps
 }) => {
   const {
@@ -155,7 +156,7 @@ const TokenInput: FC<TokenInputProps> = ({
     setAmount,
     setAmountError,
     setTokenSelected,
-  } = useTokenInput(singleToken)
+  } = useTokenInput(token)
   const { Dialog, close, open } = useDialog()
   const max = useMemo(
     () => (balance && selectedToken ? formatUnits(balance, selectedToken.decimals) : '0'),
@@ -191,6 +192,10 @@ const TokenInput: FC<TokenInputProps> = ({
   const selectIconSize = 24
   const decimals = selectedToken ? selectedToken.decimals : 2
 
+  if (singleToken && !token) {
+    return <div>When single token is true, a token is required.</div>
+  }
+
   return (
     <>
       <Wrapper {...restProps}>
@@ -212,7 +217,7 @@ const TokenInput: FC<TokenInputProps> = ({
             )}
             value={amount}
           />
-          <DropdownButton onClick={showTokenSelect} singleOption={!!singleToken}>
+          <DropdownButton onClick={showTokenSelect} singleOption={singleToken}>
             {selectedToken ? (
               <>
                 <Icon $iconSize={selectIconSize}>

--- a/src/components/sharedComponents/TokenSelect/index.tsx
+++ b/src/components/sharedComponents/TokenSelect/index.tsx
@@ -230,10 +230,10 @@ const TokenSelect = withSuspenseAndRetry<TokenSelectProps>(
       withBalance: showBalance,
     })
 
-    const { searchResult, searchTerm, setSearchTerm } = useTokenSearch(tokensByChainId[chainId], [
-      currentNetworkId,
-      tokensByChainId[chainId],
-    ])
+    const { searchResult, searchTerm, setSearchTerm } = useTokenSearch(
+      { tokens: tokensByChainId[chainId] },
+      [currentNetworkId, tokensByChainId[chainId]],
+    )
 
     return (
       <Wrapper {...restProps}>

--- a/src/hooks/useTokenSearch.ts
+++ b/src/hooks/useTokenSearch.ts
@@ -25,7 +25,7 @@ type TokenSearch = {
  * Internally it uses React's `useDeferredValue`
  *
  * @param {object} options - options object
- * @param {string} [options.defaultSearchTerm] - the default search term
+ * @param {string} [options.defaultSearchTerm] - the default search term used to find a partial match against address, symbol, and  name
  * @param {Array} options.tokens - a list of tokens to be filtered by `searchTerm`
  * @param {Array} [deps=[]] - array of dependencies that trigger recalculation of the search
  * @returns {TokenSearch} Object containing searchResult, searchTerm, and setSearchTerm

--- a/src/hooks/useTokenSearch.ts
+++ b/src/hooks/useTokenSearch.ts
@@ -9,6 +9,11 @@ import {
 
 import { type Tokens } from '@/src/types/token'
 
+type TokenSearchOptions = {
+  defaultSearchTerm?: string
+  tokens: Tokens
+}
+
 type TokenSearch = {
   searchResult: Tokens
   searchTerm: string
@@ -19,14 +24,15 @@ type TokenSearch = {
  * A hook that provides a performant search to filter a list of tokens by a searchTerm
  * Internally it uses React's `useDeferredValue`
  *
- * @param {Array} tokens - a list of tokens to be filtered by `searchTerm`
- * @param {Array | undefined} deps - array of dependencies that trigger recalculation of the search
+ * @param {object} options - options object
+ * @param {string} [options.defaultSearchTerm] - the default search term
+ * @param {Array} options.tokens - a list of tokens to be filtered by `searchTerm`
+ * @param {Array} [deps=[]] - array of dependencies that trigger recalculation of the search
  * @returns {TokenSearch} Object containing searchResult, searchTerm, and setSearchTerm
  */
 export const useTokenSearch = (
-  tokens: Tokens,
+  { defaultSearchTerm, tokens }: TokenSearchOptions,
   deps: DependencyList = [],
-  defaultSearchTerm?: string,
 ): TokenSearch => {
   const [searchTerm, setSearchTerm] = useState(defaultSearchTerm ?? '')
   const [baseList, setBaseList] = useState(tokens)


### PR DESCRIPTION
# Description:

Uses `singleToken` prop as a receiver of the required Token. This way we avoid conditionally checking things (`singleToken` vs `token`).

Also,  the `useTokenSearch` API was refactored, so it better mimics hooks API in general with the dependency array as the second parameter.


## Type of change:

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [x] Refactoring
- [ ] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)

# Remember to check that:

- Your code follows the style guidelines of this project
- You have performed a self-review of your code
- You have commented your code in hard-to-understand areas
- You have made corresponding changes to the documentation
- Your changes generate no new warnings
