### PR TITLE
feat: Change the type of contracts and make it available only through the getter.

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -8,7 +8,7 @@ export const isDev = import.meta.env.DEV
 /**
  * @source
  */
-export const includeTestNets = env.PUBLIC_INCLUDE_TESTNETS
+export const includeTestnets = env.PUBLIC_INCLUDE_TESTNETS
 
 /**
  * @source

--- a/src/constants/contracts/contracts.ts
+++ b/src/constants/contracts/contracts.ts
@@ -1,8 +1,18 @@
-import { type ContractConfig } from '@wagmi/cli'
 import { type Abi, Address, erc20Abi, isAddress } from 'viem'
+import { mainnet, sepolia } from 'viem/chains'
 
 import { ENSRegistryABI } from '@/src/constants/contracts/abis/ENSRegistry'
-import { type ChainsIds, type RequiredChainId } from '@/src/lib/networks.config'
+import { type ChainsIds } from '@/src/lib/networks.config'
+
+type ValidateId<T> = T extends ChainsIds ? T : 'Invalid ID – This ID is not permitted'
+type RequiredChainIds = ValidateId<typeof mainnet.id> // this can be extended ValidateId<typeof mainnet.id | sepolia.id | ...>
+type ContractConfigAddress = Record<RequiredChainIds, string> & Partial<Record<ChainsIds, string>>
+
+type ContractConfig = {
+  abi: Abi
+  name: string
+  address?: ContractConfigAddress
+}
 
 /**
  * A collection of contracts to be used in the dapp with their ABI and addresses per chain.
@@ -11,7 +21,7 @@ import { type ChainsIds, type RequiredChainId } from '@/src/lib/networks.config'
  *  - `RequiredChainId` is mandatory in the address object.
  *  - IDs defined `ChainIds` can be added as well if necessary.
  */
-export const contracts: Array<ContractConfig<ChainsIds, RequiredChainId>> = [
+export const contracts: Array<ContractConfig> = [
   {
     abi: erc20Abi,
     name: 'ERC20',
@@ -19,8 +29,8 @@ export const contracts: Array<ContractConfig<ChainsIds, RequiredChainId>> = [
   {
     abi: ENSRegistryABI,
     address: {
-      1: '0x314159265dd8dbb310642f98f50c066173c1259b',
-      11155111: '0x0667161579ce7e84EF2b7333f9F93375a627799B',
+      [mainnet.id]: '0x314159265dd8dbb310642f98f50c066173c1259b',
+      [sepolia.id]: '0x0667161579ce7e84EF2b7333f9F93375a627799B',
     },
     name: 'EnsRegistry',
   },

--- a/src/constants/contracts/contracts.ts
+++ b/src/constants/contracts/contracts.ts
@@ -5,7 +5,7 @@ import { ENSRegistryABI } from '@/src/constants/contracts/abis/ENSRegistry'
 import { type ChainsIds } from '@/src/lib/networks.config'
 
 type ValidateId<T> = T extends ChainsIds ? T : 'Invalid ID – This ID is not permitted'
-type RequiredChainIds = ValidateId<typeof mainnet.id> // this can be extended ValidateId<typeof mainnet.id | sepolia.id | ...>
+type RequiredChainIds = ValidateId<typeof mainnet.id> // this can be extended ValidateId<typeof mainnet.id | typeof sepolia.id | ...>
 type RequiredAddresses = Record<RequiredChainIds, Address> 
 type OptionalAddresses = Partial<Record<ChainsIds, Address>>
 

--- a/src/constants/contracts/contracts.ts
+++ b/src/constants/contracts/contracts.ts
@@ -4,17 +4,11 @@ import { mainnet, sepolia } from 'viem/chains'
 import { ENSRegistryABI } from '@/src/constants/contracts/abis/ENSRegistry'
 import { type ChainsIds } from '@/src/lib/networks.config'
 
-type ValidateId<T> = T extends ChainsIds ? T : 'Invalid ID – This ID is not permitted'
-type RequiredChainIds = ValidateId<typeof mainnet.id> // this can be extended ValidateId<typeof mainnet.id | typeof sepolia.id | ...>
-type RequiredAddresses = Record<RequiredChainIds, Address> 
 type OptionalAddresses = Partial<Record<ChainsIds, Address>>
-
-type ContractConfigAddress = RequiredAddresses & OptionalAddresses 
-
 type ContractConfig = {
   abi: Abi
   name: string
-  address?: ContractConfigAddress
+  address?: OptionalAddresses
 }
 
 /**
@@ -24,7 +18,7 @@ type ContractConfig = {
  *  - `RequiredChainId` is mandatory in the address object.
  *  - IDs defined `ChainIds` can be added as well if necessary.
  */
-export const contracts: Array<ContractConfig> = [
+const contracts: Array<ContractConfig> = [
   {
     abi: erc20Abi,
     name: 'ERC20',
@@ -43,6 +37,13 @@ type Contract = {
   abi: Abi
   address: Address
 }
+
+/**
+ * Retrieves all contracts.
+ *
+ * @returns {Array<ContractConfig>} An array containing the contracts' ABI and addresses.
+ */
+export const getContracts = () => contracts
 
 /**
  * Retrieves the contract information based on the contract name and chain ID.

--- a/src/constants/contracts/contracts.ts
+++ b/src/constants/contracts/contracts.ts
@@ -6,7 +6,10 @@ import { type ChainsIds } from '@/src/lib/networks.config'
 
 type ValidateId<T> = T extends ChainsIds ? T : 'Invalid ID – This ID is not permitted'
 type RequiredChainIds = ValidateId<typeof mainnet.id> // this can be extended ValidateId<typeof mainnet.id | sepolia.id | ...>
-type ContractConfigAddress = Record<RequiredChainIds, string> & Partial<Record<ChainsIds, string>>
+type RequiredAddresses = Record<RequiredChainIds, Address> 
+type OptionalAddresses = Partial<Record<ChainsIds, Address>>
+
+type ContractConfigAddress = RequiredAddresses & OptionalAddresses 
 
 type ContractConfig = {
   abi: Abi

--- a/src/lib/networks.config.ts
+++ b/src/lib/networks.config.ts
@@ -16,7 +16,7 @@ const allChains = [...devChains, ...prodChains] as const
 export const chains = includeTestnets ? allChains : prodChains
 export type ChainsIds = (typeof chains)[number]['id']
 
-type RestrictedTransports = Record<(typeof chains)[number]['id'], Transport>
+type RestrictedTransports = Record<ChainIds, Transport>
 export const transports: RestrictedTransports = {
   [mainnet.id]: http(env.PUBLIC_RPC_MAINNET),
   [arbitrum.id]: http(env.PUBLIC_RPC_ARBITRUM),

--- a/src/lib/networks.config.ts
+++ b/src/lib/networks.config.ts
@@ -7,7 +7,7 @@
 import { http, type Transport } from 'viem'
 import { arbitrum, mainnet, optimismSepolia, sepolia, polygon } from 'viem/chains'
 
-import { includeTestNets } from '@/src/constants/common'
+import { includeTestnets } from '@/src/constants/common'
 import { env } from '@/src/env'
 
 const devChains = [optimismSepolia, sepolia] as const
@@ -16,7 +16,7 @@ const allChains = [...devChains, ...prodChains] as const
 export const chains = includeTestnets ? allChains : prodChains
 export type ChainsIds = (typeof chains)[number]['id']
 
-type RestrictedTransports = Record<ChainIds, Transport>
+type RestrictedTransports = Record<ChainsIds, Transport>
 export const transports: RestrictedTransports = {
   [mainnet.id]: http(env.PUBLIC_RPC_MAINNET),
   [arbitrum.id]: http(env.PUBLIC_RPC_ARBITRUM),

--- a/src/lib/networks.config.ts
+++ b/src/lib/networks.config.ts
@@ -13,14 +13,10 @@ import { env } from '@/src/env'
 const devChains = [optimismSepolia, sepolia] as const
 const prodChains = [mainnet, polygon, arbitrum] as const
 const allChains = [...devChains, ...prodChains] as const
-
 export const chains = includeTestNets ? allChains : prodChains
+export type ChainsIds = (typeof chains)[number]['id']
 
 type RestrictedTransports = Record<(typeof chains)[number]['id'], Transport>
-
-export type ChainsIds = (typeof chains)[number]['id']
-export type RequiredChainId = (typeof chains)[0]['id']
-
 export const transports: RestrictedTransports = {
   [mainnet.id]: http(env.PUBLIC_RPC_MAINNET),
   [arbitrum.id]: http(env.PUBLIC_RPC_ARBITRUM),

--- a/src/lib/networks.config.ts
+++ b/src/lib/networks.config.ts
@@ -13,7 +13,7 @@ import { env } from '@/src/env'
 const devChains = [optimismSepolia, sepolia] as const
 const prodChains = [mainnet, polygon, arbitrum] as const
 const allChains = [...devChains, ...prodChains] as const
-export const chains = includeTestNets ? allChains : prodChains
+export const chains = includeTestnets ? allChains : prodChains
 export type ChainsIds = (typeof chains)[number]['id']
 
 type RestrictedTransports = Record<(typeof chains)[number]['id'], Transport>

--- a/src/lib/wagmi/config.ts
+++ b/src/lib/wagmi/config.ts
@@ -1,7 +1,7 @@
 import { type ContractConfig, defineConfig } from '@wagmi/cli'
 import { react } from '@wagmi/cli/plugins'
 
-import { contracts } from '@/src/constants/contracts/contracts'
+import { getContracts } from '@/src/constants/contracts/contracts'
 import { reactSuspenseRead } from '@/src/lib/wagmi/plugins/reactSuspenseRead'
 
 // You can extend the config object with additional properties
@@ -10,5 +10,5 @@ import { reactSuspenseRead } from '@/src/lib/wagmi/plugins/reactSuspenseRead'
 export default defineConfig({
   out: 'src/hooks/generated.ts',
   plugins: [reactSuspenseRead(), react()],
-  contracts: contracts as ContractConfig<number, undefined>[],
+  contracts: getContracts() as ContractConfig<number, undefined>[],
 })


### PR DESCRIPTION
`contracts.address` was modified to allow setting addresses for any, some, or all chains supported. 

`contracts` can not be consumed outside the file it was defined, forcing it to be consumed through the getter, which makes it safe to try to get an address if it was not defined. 