### PR TITLE
fix(chainId type): avoid using @lifi/sdk ChainId to type `chainId`

### DIFF
--- a/src/components/sharedComponents/TokenSelect/index.tsx
+++ b/src/components/sharedComponents/TokenSelect/index.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState, type HTMLAttributes, type ReactElement } from 'react'
 import styled from 'styled-components'
 
-import { type ChainId } from '@lifi/sdk'
 import { Card, Spinner } from 'db-ui-toolkit'
+import { type Chain } from 'viem/chains'
 
 import List from '@/src/components/sharedComponents/TokenSelect/List'
 import Search from '@/src/components/sharedComponents/TokenSelect/Search'
@@ -173,7 +173,7 @@ const TokenSelect = withSuspenseAndRetry<TokenSelectProps>(
   }) => {
     const { appChainId, walletChainId } = useWeb3Status()
 
-    const [chainId, setChainId] = useState<ChainId>(() =>
+    const [chainId, setChainId] = useState<Chain['id']>(() =>
       getValidChainId({
         appChainId,
         currentNetworkId,
@@ -199,23 +199,30 @@ const TokenSelect = withSuspenseAndRetry<TokenSelectProps>(
         const currentDep = currentDeps[index]
 
         if (previousDep !== currentDep) {
-          if (index === 1) {
+          const currentChainId = currentDeps[1]
+
+          if (index === 1 && !!currentChainId) {
             // currentNetworkId changed, we stick with it
-            setChainId(currentDeps[1] as ChainId)
+            setChainId(currentChainId)
           } else {
+            if (!currentDep) {
+              // if the chainId is undefined, we don't do anything
+              return
+            }
+
             // appChainId or walletChainId changed,
             //  we need to check that it's valid in the current context
             if (networks) {
               // if `networks` is defined,
               //  we need to check if the chainId is valid in the list and set it
               if (networks.some((network) => network.id === currentDep)) {
-                setChainId(currentDep as ChainId)
+                setChainId(currentDep)
               }
             } else {
               // if `networks` is not defined,
               //  we need to check if the chainId is valid in the dApp chains list and set it
               if (chains.some((chain) => chain.id === currentDep)) {
-                setChainId(currentDep as ChainId)
+                setChainId(currentDep)
               }
             }
           }
@@ -226,7 +233,7 @@ const TokenSelect = withSuspenseAndRetry<TokenSelectProps>(
     }, [appChainId, currentNetworkId, networks, walletChainId])
 
     const { isLoadingBalances, tokensByChainId } = useTokens({
-      chainId: chainId as ChainId,
+      chainId,
       withBalance: showBalance,
     })
 
@@ -272,12 +279,12 @@ function getValidChainId({
   networks,
   walletChainId,
 }: {
-  currentNetworkId?: ChainId
+  currentNetworkId?: Chain['id']
   networks?: Networks
   dappChains: typeof chains
-  walletChainId?: ChainId
+  walletChainId?: Chain['id']
   appChainId?: ChainsIds
-}) {
+}): Chain['id'] {
   // If the current network is defined, use it
   if (currentNetworkId) {
     return currentNetworkId
@@ -287,12 +294,12 @@ function getValidChainId({
   if (networks !== undefined) {
     // we prioritze the wallet chainId over the app chainId because it may be valid in this case,
     //  but not supported by the app to interact with but as a read-only chain.
-    if (networks.some((network) => network.id === walletChainId)) {
-      return walletChainId as ChainId
+    if (typeof walletChainId === 'number' && networks.some(({ id }) => id === walletChainId)) {
+      return walletChainId
     }
 
-    if (networks.some((network) => network.id === appChainId)) {
-      return appChainId as ChainId
+    if (typeof appChainId === 'number' && networks.some(({ id }) => id === appChainId)) {
+      return appChainId
     }
 
     // if nothing matches, we default to the first network in the list
@@ -301,12 +308,12 @@ function getValidChainId({
 
   // if `networks` is not defined, we need to verify the dApp configuration
   // Same as before, we prioritize the wallet chainId over the app chainId
-  if (dappChains.some((chain) => chain.id === walletChainId)) {
-    return walletChainId as ChainId
+  if (typeof walletChainId === 'number' && dappChains.some(({ id }) => id === walletChainId)) {
+    return walletChainId
   }
 
-  if (dappChains.some((chain) => chain.id === appChainId)) {
-    return appChainId as ChainId
+  if (typeof appChainId === 'number' && dappChains.some(({ id }) => id === appChainId)) {
+    return appChainId
   }
 
   // if nothing matches, we default to the first chain in the list

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -8,10 +8,9 @@ import {
   type TokenAmount,
   type TokensResponse,
   getChains,
-  type ChainId,
 } from '@lifi/sdk'
 import { useQuery } from '@tanstack/react-query'
-import { type Address, formatUnits } from 'viem'
+import { type Address, Chain, formatUnits } from 'viem'
 
 import { env } from '@/src/env'
 import { useTokenLists } from '@/src/hooks/useTokenLists'
@@ -43,7 +42,7 @@ export const useTokens = (
     account,
     chainId,
     withBalance,
-  }: { account?: Address; chainId?: ChainId; withBalance?: boolean } = {
+  }: { account?: Address; chainId?: Chain['id']; withBalance?: boolean } = {
     withBalance: true,
   },
 ) => {


### PR DESCRIPTION
Closes #223

# Description:

Also, I properly narrowed types for values which allowed the removal of type assertions as well.

# Steps:

Test by adding networks not supported by lifi that tsc stop complaining.

## Type of change:

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [x] Refactoring
- [ ] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)

# Remember to check that:

- Your code follows the style guidelines of this project
- You have performed a self-review of your code
- You have commented your code in hard-to-understand areas
- You have made corresponding changes to the documentation
- Your changes generate no new warnings

# Screenshots

(Add screenshots or videos to help test this pull request)
