### PR TITLE
chore: change db-ui-toolkit to npm registry's version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@uniswap/default-token-list": "^11.19.0",
     "@vercel/analytics": "^1.3.1",
     "connectkit": "^1.8.2",
-    "db-ui-toolkit": "github:BootNodeDev/db-ui-toolkit#0.3.7",
+    "db-ui-toolkit": "^0.3.7",
     "graphql": "^16.9.0",
     "graphql-request": "^7.1.0",
     "modern-normalize": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^1.8.2
         version: 1.8.2(@babel/core@7.24.7)(@tanstack/react-query@5.50.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(viem@2.10.11(bufferutil@4.0.8)(typescript@5.5.3)(utf-8-validate@5.0.10)(zod@3.23.8))(wagmi@2.10.9(@tanstack/query-core@5.50.1)(@tanstack/react-query@5.50.1(react@18.3.1))(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.18.0)(typescript@5.5.3)(utf-8-validate@5.0.10)(viem@2.10.11(bufferutil@4.0.8)(typescript@5.5.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8))
       db-ui-toolkit:
-        specifier: github:BootNodeDev/db-ui-toolkit#0.3.7
-        version: https://codeload.github.com/BootNodeDev/db-ui-toolkit/tar.gz/28248b8480667f94fe1273c2876d13c41072420b
+        specifier: ^0.3.7
+        version: 0.3.7
       graphql:
         specifier: ^16.9.0
         version: 16.9.0
@@ -3756,9 +3756,8 @@ packages:
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
-  db-ui-toolkit@https://codeload.github.com/BootNodeDev/db-ui-toolkit/tar.gz/28248b8480667f94fe1273c2876d13c41072420b:
-    resolution: {tarball: https://codeload.github.com/BootNodeDev/db-ui-toolkit/tar.gz/28248b8480667f94fe1273c2876d13c41072420b}
-    version: 0.1.0
+  db-ui-toolkit@0.3.7:
+    resolution: {integrity: sha512-hOlmFVxYdEAwglt4BttkpNq4E+FMiTTa0lo4kSnXuo1vG+werRhR+1XRWqLziwOqbjKJomlJIOA8K0eAwfXFhg==}
     engines: {node: '>=20.0.0'}
 
   debounce@1.2.1:
@@ -12409,7 +12408,7 @@ snapshots:
 
   dayjs@1.11.13: {}
 
-  db-ui-toolkit@https://codeload.github.com/BootNodeDev/db-ui-toolkit/tar.gz/28248b8480667f94fe1273c2876d13c41072420b:
+  db-ui-toolkit@0.3.7:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
# Description:

Finally published `db-ui-toolkit` to the NPM Registry, so I updated `package.json` so it points there.

It's the same `0.3.7` version, so there should be no other changes and things should work the same (for better or worse).

## Type of change:

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [ ] Refactoring
- [x] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)