### PR TITLE
fix: font size and more

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@uniswap/default-token-list": "^11.19.0",
     "@vercel/analytics": "^1.3.1",
     "connectkit": "^1.8.2",
-    "db-ui-toolkit": "^0.3.7",
+    "db-ui-toolkit": "^0.3.8",
     "graphql": "^16.9.0",
     "graphql-request": "^7.1.0",
     "modern-normalize": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         specifier: ^1.8.2
         version: 1.8.2(@babel/core@7.25.2)(@tanstack/react-query@5.52.2(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(viem@2.10.11(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.23.8))(wagmi@2.12.7(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.21.1)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.10.11(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8))
       db-ui-toolkit:
-        specifier: ^0.3.7
+        specifier: ^0.3.8
         version: 0.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       graphql:
         specifier: ^16.9.0

--- a/src/components/pageComponents/home/index.tsx
+++ b/src/components/pageComponents/home/index.tsx
@@ -46,7 +46,7 @@ const Ul = styled.ul`
  * A styled pre tag
  */
 const Code = styled.pre`
-  background-color: #f5f5f5;
+  background-color: var(--theme-body-background-color);
   border-radius: 5px;
   font-size: 1.3rem;
   margin: var(--base-gap) 0 0;

--- a/src/components/sharedComponents/ConnectButton.tsx
+++ b/src/components/sharedComponents/ConnectButton.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components'
 
-import { Button } from 'db-ui-toolkit'
+import { Button, breakpointMediaQuery } from 'db-ui-toolkit'
 
 const BaseChevronDown = ({ ...restProps }) => (
   <svg
@@ -38,8 +38,8 @@ const ConnectButton = styled(Button).attrs<ConnectButtonProps>(({ $isConnected, 
     ),
   }
 })`
+  font-size: 1.4rem;
   font-weight: 700;
-  font-size: 1.5rem;
   height: 48px;
 
   ${({ $isConnected }) =>
@@ -51,6 +51,13 @@ const ConnectButton = styled(Button).attrs<ConnectButtonProps>(({ $isConnected, 
       padding-left: var(--base-common-padding);
       padding-right: var(--base-common-padding);
     `}
+
+  ${breakpointMediaQuery(
+    'tabletLandscapeStart',
+    css`
+      font-size: 1.6rem;
+    `,
+  )}
 `
 
 export default ConnectButton

--- a/src/components/sharedComponents/Header.tsx
+++ b/src/components/sharedComponents/Header.tsx
@@ -41,9 +41,18 @@ const Start = styled.div`
 `
 
 const HomeLink = styled(Link)`
+  display: none;
+
   &:active {
     opacity: 0.7;
   }
+
+  ${breakpointMediaQuery(
+    'tabletPortraitStart',
+    css`
+      display: flex;
+    `,
+  )}
 `
 
 const Logo = styled(BaseLogo)`


### PR DESCRIPTION
Closes #255

# Description:

A few fixes:

- Connect button font size (14px / 12px for mobile, 16px for tablets and up) -> 3e91cc8575efb825e318203daa848339d716e6af
- `code` HTML tag text color for dark mode -> 747af989849417cca41796fbf23f8c0510a98d80
- App's logo is hidden on mobile to fit theme and connect button in header -> 12a17fdc7106645b4d203daf2d583654c89a8361

## Type of change:

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [ ] Refactoring
- [ ] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)

# Remember to check that:

- Your code follows the style guidelines of this project
- You have performed a self-review of your code
- You have commented your code in hard-to-understand areas
- You have made corresponding changes to the documentation
- Your changes generate no new warnings

# Screenshots

![image](https://github.com/user-attachments/assets/35a15300-dc9b-4ac9-9972-897af9a02d16)
![image](https://github.com/user-attachments/assets/62951593-3e48-4397-9252-a2d36efbaa8f)

![image](https://github.com/user-attachments/assets/a9b76ad7-6aa2-49a7-953a-5fa9c4b3cf4e)

