### PR TITLE
fix: token input breaks with numbers >= 1000

### DIFF
--- a/src/components/sharedComponents/BigNumberInput.tsx
+++ b/src/components/sharedComponents/BigNumberInput.tsx
@@ -63,7 +63,7 @@ export const BigNumberInput: FC<BigNumberInputProps> = ({
     if (!current) {
       return
     }
-    const currentInputValue = parseUnits(current.value || '0', decimals)
+    const currentInputValue = parseUnits(current.value.replace(/,/g, '') || '0', decimals)
 
     if (currentInputValue !== value) {
       current.value = formatUnits(value, decimals)


### PR DESCRIPTION
Closes #293

# Description:

The number formatter returns a string with a comma separating the thousands in the value, which leads to an error when trying to convert that string to bigint.

# Steps:

test it

## Type of change:

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [ ] Refactoring
- [ ] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)

# Remember to check that:

- Your code follows the style guidelines of this project
- You have performed a self-review of your code
- You have commented your code in hard-to-understand areas
- You have made corresponding changes to the documentation
- Your changes generate no new warnings

# Screenshots

(Add screenshots or videos to help test this pull request)
