### PR TITLE
chore(tsc): remove flag `verbatimModuleSyntax` from pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,7 +2,7 @@
 
 # Run tsc
 echo "Running TS checks..."
-pnpm tsc --pretty --noEmit --verbatimModuleSyntax
+pnpm tsc --pretty --noEmit
 
 # Check result
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
# Description:

Removes the flag `verbatimModuleSyntax` passed to the `tsc` command on the `pre-push` hook.

This brought more issues than solutions, and we have the' types' import covered from the ESLINT rules included by @gabitoesmiapodo in the PR #310.

# Steps:

Be sure that a push triggers the pre-push hook

## Type of change:

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [x] Refactoring
- [ ] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)

# Remember to check that:

- Your code follows the style guidelines of this project
- You have performed a self-review of your code
- You have commented your code in hard-to-understand areas
- You have made corresponding changes to the documentation
- Your changes generate no new warnings

# Screenshots

(Add screenshots or videos to help test this pull request)
