### PR TITLE
feat: add getTransactionOutputs utility with event log parsing

### DIFF
--- a/src/utils/getTransactionOutputs.test.ts
+++ b/src/utils/getTransactionOutputs.test.ts
@@ -1,0 +1,174 @@
+import { type Abi, type TransactionReceipt, decodeEventLog } from 'viem'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  MissingOutputError,
+  TransactionOutputError,
+  getTransactionOutputs,
+} from '@/src/utils/getTransactionOutputs'
+
+// Mock the viem decodeEventLog function
+vi.mock('viem', async () => {
+  const actual = await vi.importActual('viem')
+  return {
+    ...actual,
+    decodeEventLog: vi.fn((args) => {
+      // Mock implementation that simulates event decoding
+      if (args.topics[0] === '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef') {
+        return {
+          eventName: 'Transfer',
+          args: {
+            from: '0x0000000000000000000000000000000000000000',
+            to: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            tokenId: '0x0000000000000000000000000000000000000000000000000000000000000001',
+          },
+        }
+      }
+      throw new Error('Unknown event')
+    }),
+  }
+})
+
+describe('getTransactionOutputs', () => {
+  // Mock ABI for testing
+  const mockAbi = [
+    {
+      type: 'event',
+      name: 'Transfer',
+      inputs: [
+        { indexed: true, name: 'from', type: 'address' },
+        { indexed: true, name: 'to', type: 'address' },
+        { indexed: true, name: 'tokenId', type: 'uint256' },
+      ],
+    },
+  ] as const satisfies Abi
+
+  // Mock successful transaction receipt
+  const mockSuccessReceipt: TransactionReceipt = {
+    logs: [
+      {
+        address: '0x123',
+        topics: [
+          '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef', // Transfer event signature
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+          '0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        ],
+        data: '0x',
+        blockHash: '0x123',
+        blockNumber: 1n,
+        logIndex: 0,
+        removed: false,
+        transactionHash: '0x123',
+        transactionIndex: 0,
+      },
+    ],
+    blockHash: '0x123',
+    blockNumber: 1n,
+    transactionHash: '0x123',
+    from: '0x123',
+    to: '0x123',
+    status: 'success',
+    contractAddress: null,
+    gasUsed: 21000n,
+    effectiveGasPrice: 1n,
+    cumulativeGasUsed: 21000n,
+    type: 'eip1559',
+    logsBloom: '0x0',
+    transactionIndex: 0,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  it('successfully extracts hex values from transaction logs', () => {
+    const outputs = getTransactionOutputs(mockSuccessReceipt, mockAbi, ['to', 'tokenId'] as const)
+
+    expect(outputs).toEqual({
+      to: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      tokenId: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    })
+    expect(decodeEventLog).toHaveBeenCalled()
+  })
+
+  it('throws MissingOutputError when required outputs are not found', () => {
+    expect(() =>
+      getTransactionOutputs(mockSuccessReceipt, mockAbi, ['nonexistent'] as const),
+    ).toThrow(MissingOutputError)
+  })
+
+  it('returns partial results when throwOnMissing is false', () => {
+    const outputs = getTransactionOutputs(
+      mockSuccessReceipt,
+      mockAbi,
+      ['to', 'nonexistent'] as const,
+      { throwOnMissing: false },
+    )
+
+    expect(outputs).toEqual({
+      to: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    })
+  })
+
+  it('logs decode errors when logDecodeErrors is true', () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn')
+    const invalidReceipt: TransactionReceipt = {
+      ...mockSuccessReceipt,
+      logs: [
+        {
+          ...mockSuccessReceipt.logs[0],
+          topics: ['0xinvalid'],
+        },
+      ],
+    }
+
+    getTransactionOutputs(invalidReceipt, mockAbi, ['to'] as const, {
+      throwOnMissing: false,
+      logDecodeErrors: true,
+    })
+
+    expect(consoleWarnSpy).toHaveBeenCalled()
+  })
+
+  it('handles empty logs array', () => {
+    const emptyReceipt: TransactionReceipt = {
+      ...mockSuccessReceipt,
+      logs: [],
+    }
+
+    expect(() => getTransactionOutputs(emptyReceipt, mockAbi, ['to'] as const)).toThrow(
+      MissingOutputError,
+    )
+  })
+
+  it('processes multiple logs to find all required outputs', () => {
+    const multiLogReceipt: TransactionReceipt = {
+      ...mockSuccessReceipt,
+      logs: [
+        mockSuccessReceipt.logs[0],
+        {
+          ...mockSuccessReceipt.logs[0],
+          topics: [
+            '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+            '0x000000000000000000000000b0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            '0x0000000000000000000000000000000000000000000000000000000000000002',
+          ],
+        },
+      ],
+    }
+
+    const outputs = getTransactionOutputs(multiLogReceipt, mockAbi, ['to'] as const)
+    expect(outputs).toEqual({
+      to: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    })
+  })
+
+  it('throws TransactionOutputError for invalid receipt', () => {
+    expect(() =>
+      getTransactionOutputs(null as unknown as TransactionReceipt, mockAbi, ['to'] as const),
+    ).toThrow(TransactionOutputError)
+  })
+})

--- a/src/utils/getTransactionOutputs.ts
+++ b/src/utils/getTransactionOutputs.ts
@@ -1,0 +1,125 @@
+import { type Abi, type TransactionReceipt, decodeEventLog } from 'viem'
+
+/**
+ * Custom error class for transaction output processing errors
+ */
+export class TransactionOutputError extends Error {
+  constructor(
+    message: string,
+    public readonly details?: unknown,
+  ) {
+    super(message)
+    this.name = 'TransactionOutputError'
+  }
+}
+
+/**
+ * Error thrown when required outputs are not found in transaction logs
+ */
+export class MissingOutputError extends TransactionOutputError {
+  constructor(public readonly missingKeys: string[]) {
+    super(`Missing required outputs: ${missingKeys.join(', ')}`)
+    this.name = 'MissingOutputError'
+  }
+}
+
+/**
+ * Type guard to check if a value is a hex string
+ * @param value - Value to check
+ * @returns True if the value is a hex string starting with '0x'
+ */
+function isHexString(value: unknown): value is `0x${string}` {
+  return typeof value === 'string' && value.startsWith('0x')
+}
+
+/**
+ * Extracts specified output values from transaction event logs
+ *
+ * @description
+ * This function processes transaction logs to extract specified output values from event arguments.
+ * It decodes event logs using the provided ABI and collects values for the requested output keys.
+ *
+ * @param receipt - The transaction receipt containing event logs
+ * @param abi - The ABI used to decode the event logs
+ * @param expectedOutputs - Array of output keys to extract from event args
+ * @param options - Configuration options
+ * @param options.throwOnMissing - If true, throws when required outputs are not found (default: true)
+ * @param options.logDecodeErrors - If true, logs errors when decoding events fails (default: false)
+ *
+ * @returns Object containing the requested output values as hex strings
+ *
+ * @throws {MissingOutputError} When required outputs are not found and throwOnMissing is true
+ * @throws {TransactionOutputError} When transaction processing fails
+ *
+ * @example
+ * ```ts
+ * const receipt = await getTransactionReceipt(hash)
+ * const outputs = getTransactionOutputs(
+ *   receipt,
+ *   abi,
+ *   ['tokenId', 'to'],
+ *   { throwOnMissing: true }
+ * )
+ * // outputs = { tokenId: '0x...', to: '0x...' }
+ * ```
+ */
+export function getTransactionOutputs<
+  T extends readonly string[],
+  A extends Abi,
+  ThrowOnMissing extends boolean = true,
+>(
+  receipt: TransactionReceipt,
+  abi: A,
+  expectedOutputs: T,
+  options: {
+    throwOnMissing?: ThrowOnMissing
+    logDecodeErrors?: boolean
+  } = {},
+): ThrowOnMissing extends true
+  ? { [K in T[number]]: `0x${string}` }
+  : Partial<{ [K in T[number]]: `0x${string}` }> {
+  const { logDecodeErrors = false, throwOnMissing = true } = options
+
+  const expectedOutputsSet = new Set(expectedOutputs)
+  const outputs: Partial<{ [K in T[number]]: `0x${string}` }> = {}
+
+  try {
+    for (const log of receipt.logs) {
+      try {
+        const decodedLog = decodeEventLog({
+          abi,
+          data: log.data,
+          topics: log.topics,
+        })
+
+        if (decodedLog.args) {
+          for (const [key, value] of Object.entries(decodedLog.args)) {
+            if (expectedOutputsSet.has(key) && isHexString(value) && !(key in outputs)) {
+              outputs[key as keyof typeof outputs] = value
+            }
+          }
+        }
+      } catch (error) {
+        if (logDecodeErrors) {
+          console.warn('Failed to decode log:', error)
+        }
+      }
+    }
+
+    if (throwOnMissing) {
+      const missingOutputs = expectedOutputs.filter((key) => !(key in outputs))
+      if (missingOutputs.length > 0) {
+        throw new MissingOutputError(missingOutputs)
+      }
+    }
+
+    return outputs as ThrowOnMissing extends true
+      ? { [K in T[number]]: `0x${string}` }
+      : Partial<{ [K in T[number]]: `0x${string}` }>
+  } catch (error) {
+    if (error instanceof TransactionOutputError) {
+      throw error
+    }
+    throw new TransactionOutputError('Failed to process transaction outputs', error)
+  }
+}


### PR DESCRIPTION
Closes #

# Description:
Add getTransactionOutputs utility to extract and parse event outputs from transaction receipts. This utility provides a type-safe way to extract specific values from Ethereum transaction logs, with configurable error handling and partial result support.

Key features:
- Type-safe extraction of event outputs
- Configurable error handling
- Support for partial results
- Comprehensive error types for better error handling
- Full TypeScript support with generics

# Steps:
1. Import the utility from the utils folder
2. Prepare your transaction receipt and ABI
3. Specify the output keys you want to extract
4. Configure error handling options if needed
5. Use the returned hex values as needed

## Type of change:

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [ ] Refactoring
- [ ] Chore

# How Has This Been Tested?

- [x] Manual testing
- [x] Automated tests
  - Success case for extracting hex values
  - Error handling for missing outputs
  - Partial results with throwOnMissing flag
  - Log decode error handling
  - Empty logs handling
  - Multiple transaction logs processing
  - Invalid receipt validation

# Remember to check that:

- [x] Your code follows the style guidelines of this project
- [x] You have performed a self-review of your code
- [x] You have commented your code in hard-to-understand areas
- [x] You have made corresponding changes to the documentation
- [x] Your changes generate no new warnings

# Screenshots
N/A - Utility function addition