### PR TITLE
feat: add missing native tokens icons

### DIFF
--- a/src/components/sharedComponents/TokenSelect/List/Row.tsx
+++ b/src/components/sharedComponents/TokenSelect/List/Row.tsx
@@ -12,7 +12,8 @@ const Icon: FC<{ size: number } & FlexProps> = ({ size, children, ...restProps }
     height={`${size}px`}
     justifyContent="center"
     overflow="hidden"
-    width={`${size}px"`}
+    width={`${size}px`}
+    flexShrink={0}
     {...restProps}
   >
     {children}
@@ -89,12 +90,21 @@ const Row: FC<TokenSelectRowProps> = ({
       onClick={() => onClick(token)}
       {...restProps}
     >
-      <Icon size={iconSize}>
-        <TokenLogo
-          size={iconSize}
-          token={token}
-        />
-      </Icon>
+      <Box
+        rounded="full"
+        overflow="hidden"
+      >
+        <Icon size={iconSize}>
+          {token.icon ? (
+            token.icon({ size: iconSize })
+          ) : (
+            <TokenLogo
+              size={iconSize}
+              token={token}
+            />
+          )}
+        </Icon>
+      </Box>
       <Box
         color="var(--row-token-name-color)"
         fontSize="18px"

--- a/src/components/sharedComponents/TokenSelect/TopTokens/Item.tsx
+++ b/src/components/sharedComponents/TokenSelect/TopTokens/Item.tsx
@@ -49,10 +49,14 @@ const Item: FC<ItemProps> = ({ token, ...restProps }) => {
         overflow="hidden"
         width={`${ICON_SIZE}px"`}
       >
-        <TokenLogo
-          size={ICON_SIZE}
-          token={token}
-        />
+        {token.icon ? (
+          token.icon({ size: ICON_SIZE })
+        ) : (
+          <TokenLogo
+            size={ICON_SIZE}
+            token={token}
+          />
+        )}
       </Flex>
       <Box
         color="var(--top-token-item-color)"

--- a/src/hooks/useTokenLists.tsx
+++ b/src/hooks/useTokenLists.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { type JSX, useMemo } from 'react'
 
 import {
   type UseSuspenseQueryOptions,
@@ -13,6 +13,40 @@ import { env } from '@/src/env'
 import { type Token, type TokenList, tokenSchema } from '@/src/types/token'
 import { logger } from '@/src/utils/logger'
 import tokenListsCache, { updateTokenListsCache, type TokensMap } from '@/src/utils/tokenListsCache'
+
+import {
+  NetworkArbitrumOne,
+  NetworkEthereum,
+  NetworkOptimism,
+  NetworkPolygon,
+} from '@web3icons/react'
+
+const nativeTokenIcons: Record<number, (props: { size: number }) => JSX.Element> = {
+  1: (props) => (
+    <NetworkEthereum
+      variant="background"
+      {...props}
+    />
+  ),
+  10: (props) => (
+    <NetworkOptimism
+      variant="background"
+      {...props}
+    />
+  ),
+  42161: (props) => (
+    <NetworkArbitrumOne
+      variant="background"
+      {...props}
+    />
+  ),
+  137: (props) => (
+    <NetworkPolygon
+      variant="background"
+      {...props}
+    />
+  ),
+}
 
 /**
  * Loads and processes token lists from configured sources
@@ -186,5 +220,6 @@ function buildNativeToken(chainId: Token['chainId']): Token {
     chainId: chainId,
     decimals: tokenInfo.decimals,
     symbol: tokenInfo.symbol,
+    icon: nativeTokenIcons[chainId],
   }
 }

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { z } from 'zod'
 
 const address = z.string().regex(/^0x[a-fA-F0-9]{40}$/)
@@ -36,7 +37,9 @@ export const tokenSchema = z.object({
  */
 export const tokensSchema = z.array(tokenSchema)
 
-export type Token = z.infer<typeof tokenSchema>
+export type Token = z.infer<typeof tokenSchema> & {
+  icon?: (props: { size: number }) => JSX.Element
+}
 
 export type Tokens = z.infer<typeof tokensSchema>
 


### PR DESCRIPTION
Closes #164 

# Description:

This PR adds the missing icon to the native tokens: 
- Create a mapping from chainId in useTokenLists.tsx
- Add the icon property to the returned object in useTokenLists.tsx
- Add token type icon property (token.ts)
- Render each token in the token list (Row.tsx and Item.tsx)

# Steps:

Navigate to the Token Input demo, select the multi-token option, and open the Select Token modal. In both lists (Top and Full) the first icon should display the network token icon.


## Type of change:

- [x] New feature
- [x] Enhancement

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)

# Remember to check that:

- Your code follows the style guidelines of this project
- You have performed a self-review of your code
- You have commented your code in hard-to-understand areas
- You have made corresponding changes to the documentation
- Your changes generate no new warnings

# Screenshots

![image](https://github.com/user-attachments/assets/9f8ccaea-1d9e-4405-9362-c3799270a9bd)
![image](https://github.com/user-attachments/assets/93a5ee26-13a4-4022-b7e4-cb910770b9fc)
![image](https://github.com/user-attachments/assets/0179e581-36e2-4278-8c9a-42ec02858e6f)
![image](https://github.com/user-attachments/assets/fc5cb974-3b34-460c-8fe0-34fcdb38240e)

