### PR TITLE
fix: SwitchNetwork dropdown shows only first network item

### DIFF
--- a/src/components/sharedComponents/ui/Menu/index.tsx
+++ b/src/components/sharedComponents/ui/Menu/index.tsx
@@ -10,6 +10,7 @@ export const MenuContent: FC<MenuContentProps> = ({ children, css, ...restProps 
     css={{ ...css, ...styles }}
     padding="0"
     display="flex"
+    flexDirection="column"
     alignItems="stretch"
     {...restProps}
   >


### PR DESCRIPTION
## Summary

<!-- Why this change? What problem does it solve? Link motivation, not just mechanics. -->

Closes #443

## Changes

<!-- Brief description of what was changed. Bullet points work well. -->

- Add `flexDirection="column"` to `MenuContent` in `src/components/sharedComponents/ui/Menu/index.tsx`

## Acceptance criteria

<!-- Mirror the criteria from the linked issue. Check them off as you go. -->

- [x] All 4 configured networks are visible in the "Add / switch network" demo dropdown
- [x] No unintended scrolling is reintroduced

## Test plan

<!-- How was this tested? Commands, screenshots, recordings — show your work. -->

1. `pnpm dev`
2. Open home page, find the "Add / switch network" example card
3. Click "Demo", then "Select a network"
4. All 4 networks (Ethereum, OP Mainnet, Arbitrum One, Polygon) should be visible and selectable

## Breaking changes

<!-- If none, delete this section. If any, describe what breaks and migration steps. -->

None.

## Checklist

- [x] Self-reviewed my own diff
- [x] Tests added or updated
- [x] Docs updated (if applicable)
- [x] No unrelated changes bundled in

## Screenshots

https://github.com/user-attachments/assets/a9526bdd-97a8-413d-bf9e-fafa64a89eec
