### PR TITLE
test: add coverage for fetchTokenList('default') bundled token path

### DIFF
--- a/src/hooks/useTokenLists.test.ts
+++ b/src/hooks/useTokenLists.test.ts
@@ -164,7 +164,7 @@ describe('fetchTokenList', () => {
       expect(result.tokens.length).toBeGreaterThan(0)
     })
 
-    it('every EVM token entry conforms to tokenSchema', async () => {
+    it('every EVM token conforms to tokenSchema', async () => {
       const result = await fetchTokenList('default')
 
       // The bundled list includes non-EVM tokens (e.g. Solana with base58 addresses)

--- a/src/hooks/useTokenLists.test.ts
+++ b/src/hooks/useTokenLists.test.ts
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 import { createElement } from 'react'
 import { zeroAddress } from 'viem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Token } from '@/src/types/token'
+import { type Token, tokenSchema } from '@/src/types/token'
 import tokenListsCache, { updateTokenListsCache } from '@/src/utils/tokenListsCache'
 
 vi.mock('@/src/utils/tokenListsCache', () => {
@@ -154,6 +154,28 @@ describe('fetchTokenList', () => {
 
     expect(result.tokens).toEqual([])
     warnSpy.mockRestore()
+  })
+
+  describe("'default' bundled token list", () => {
+    it('returns a non-empty tokens array', async () => {
+      const result = await fetchTokenList('default')
+
+      expect(Array.isArray(result.tokens)).toBe(true)
+      expect(result.tokens.length).toBeGreaterThan(0)
+    })
+
+    it('every EVM token entry conforms to tokenSchema', async () => {
+      const result = await fetchTokenList('default')
+
+      // The bundled list includes non-EVM tokens (e.g. Solana with base58 addresses)
+      // alongside EVM tokens. Non-EVM entries are filtered out downstream by useTokenLists
+      // via safeParse. Here we validate only the EVM-addressable subset.
+      const evmTokens = result.tokens.filter(({ address }) => /^0x[a-fA-F0-9]{40}$/.test(address))
+      expect(evmTokens.length).toBeGreaterThan(0)
+      for (const token of evmTokens) {
+        expect(() => tokenSchema.parse(token)).not.toThrow()
+      }
+    })
   })
 })
 

--- a/src/hooks/useTokenLists.test.ts
+++ b/src/hooks/useTokenLists.test.ts
@@ -160,8 +160,8 @@ describe('fetchTokenList', () => {
     it('returns a non-empty tokens array', async () => {
       const result = await fetchTokenList('default')
 
-      expect(Array.isArray(result.tokens)).toBe(true)
       expect(result.tokens.length).toBeGreaterThan(0)
+      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it('every EVM token conforms to tokenSchema', async () => {
@@ -175,6 +175,7 @@ describe('fetchTokenList', () => {
       for (const token of evmTokens) {
         expect(() => tokenSchema.parse(token)).not.toThrow()
       }
+      expect(mockFetch).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/hooks/useTokenLists.ts
+++ b/src/hooks/useTokenLists.ts
@@ -98,7 +98,10 @@ function combineTokenLists(results: Array<UseSuspenseQueryResult<TokenList>>): T
     new Map(
       results
         .flatMap((result) => result.data.tokens)
-        // ensure that only valid tokens are consumed in runtime
+        // tokenSchema enforces EVM address format (0x + 40 hex chars), so non-EVM entries
+        // (e.g. Solana tokens from @uniswap/default-token-list v18+) are silently dropped here.
+        // Supporting non-EVM chains would require changes to the address schema, chain config,
+        // wallet integration, and contract lookup -- out of scope for this EVM-focused starter kit.
         .filter((token) => {
           const result = tokenSchema.safeParse(token)
 


### PR DESCRIPTION
## Summary

<!-- Why this change? What problem does it solve? Link motivation, not just mechanics. -->

`fetchTokenList('default')` -- the code path returning the bundled `@uniswap/default-token-list` -- had zero test coverage. A major version bump (v13 to v18 in #434) could silently break the data shape with no automated detection.

Closes #438

## Changes

<!-- Brief description of what was changed. Bullet points work well. -->

- Added `tokenSchema` to the imports in `src/hooks/useTokenLists.test.ts`
- Added a `'default' bundled token list` describe block with two tests for `fetchTokenList('default')`
- Added a comment in `useTokenLists.ts` at the `safeParse` filter explaining why non-EVM tokens (e.g. Solana) are dropped and that supporting them requires broader changes

## Acceptance criteria

<!-- Mirror the criteria from the linked issue. Check them off as you go. -->

- [x] `fetchTokenList('default')` is called in a test without mocking `@uniswap/default-token-list` away
- [x] The test asserts the result has a non-empty `tokens` array and that entries conform to `tokenSchema`
- [x] Existing tests remain unaffected

## Test plan

<!-- How was this tested? Commands, screenshots, recordings — show your work. -->

```
pnpm test src/hooks/useTokenLists.test.ts  # 11 tests pass (2 new)
pnpm test                                  # 172 tests pass
pnpm lint                                  # clean
```

**Note:** the v18 bundled list includes 173 Solana tokens with base58 addresses that fail the EVM address regex. The schema test filters to `^0x[a-fA-F0-9]{40}$` addresses before calling `tokenSchema.parse()`, mirroring how `useTokenLists` filters them out downstream via `safeParse`.

## Checklist

- [x] Self-reviewed my own diff
- [x] Tests added or updated
- [ ] Docs updated (if applicable)
- [x] No unrelated changes bundled in