### PR TITLE
fix(token-input): format max value with thousand separators

### DIFF
--- a/src/components/sharedComponents/BigNumberInput.test.tsx
+++ b/src/components/sharedComponents/BigNumberInput.test.tsx
@@ -1,8 +1,9 @@
 import { ChakraProvider, createSystem, defaultConfig } from '@chakra-ui/react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ComponentProps } from 'react'
-import { maxUint256 } from 'viem'
+import { NumericFormat } from 'react-number-format'
+import { maxUint256, parseUnits } from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 import { BigNumberInput } from './BigNumberInput'
 
@@ -122,5 +123,74 @@ describe('BigNumberInput', () => {
     const input = screen.getByRole('textbox')
     await userEvent.type(input, '9999999')
     expect(onError).not.toHaveBeenCalled()
+  })
+})
+
+describe('BigNumberInput with renderInput (NumericFormat)', () => {
+  function renderWithNumericFormat(
+    props: Partial<ComponentProps<typeof BigNumberInput>> & {
+      onChange?: (v: bigint) => void
+    } = {},
+    initialValue = BigInt(0),
+  ) {
+    const onChange = props.onChange ?? vi.fn()
+
+    const makeJsx = (value: bigint) => (
+      <ChakraProvider value={system}>
+        <BigNumberInput
+          decimals={18}
+          value={value}
+          onChange={onChange}
+          renderInput={({ onChange: handleChange, value: displayVal, ...restProps }) => (
+            <NumericFormat
+              thousandSeparator
+              onValueChange={({ value: v }) => handleChange(v)}
+              value={displayVal}
+              {...restProps}
+            />
+          )}
+          {...props}
+        />
+      </ChakraProvider>
+    )
+
+    const { container, rerender } = render(makeJsx(initialValue))
+
+    return {
+      input: container.querySelector('input') as HTMLInputElement,
+      onChange,
+      rerender: (newValue: bigint) => rerender(makeJsx(newValue)),
+    }
+  }
+
+  it('shows empty input (placeholder) when value is 0n', () => {
+    const { input } = renderWithNumericFormat()
+    expect(input.value).toBe('')
+  })
+
+  it('formats value with thousand separators when value changes externally', async () => {
+    const { input, rerender } = renderWithNumericFormat()
+    rerender(parseUnits('1000', 18))
+    await waitFor(() => {
+      expect(input.value).toBe('1,000')
+    })
+  })
+
+  it('shows empty input after value resets to 0n', async () => {
+    const { input, rerender } = renderWithNumericFormat()
+    rerender(parseUnits('1000', 18))
+    await waitFor(() => {
+      expect(input.value).toBe('1,000')
+    })
+    rerender(BigInt(0))
+    await waitFor(() => {
+      expect(input.value).toBe('')
+    })
+  })
+
+  it('preserves user-typed "0" without clearing to placeholder', async () => {
+    const { input } = renderWithNumericFormat()
+    await userEvent.type(input, '0')
+    expect(input.value).toBe('0')
   })
 })

--- a/src/components/sharedComponents/BigNumberInput.test.tsx
+++ b/src/components/sharedComponents/BigNumberInput.test.tsx
@@ -194,4 +194,9 @@ describe('BigNumberInput with renderInput (NumericFormat)', () => {
     await userEvent.type(input, '0')
     expect(input.value).toBe('0')
   })
+
+  it('shows formatted initial value when mounted with non-zero value', () => {
+    const { input } = renderWithNumericFormat({}, parseUnits('1000', 18))
+    expect(input.value).toBe('1,000')
+  })
 })

--- a/src/components/sharedComponents/BigNumberInput.test.tsx
+++ b/src/components/sharedComponents/BigNumberInput.test.tsx
@@ -141,7 +141,12 @@ describe('BigNumberInput with renderInput (NumericFormat)', () => {
           decimals={18}
           value={value}
           onChange={onChange}
-          renderInput={({ onChange: handleChange, value: displayVal, ...restProps }) => (
+          renderInput={({
+            onChange: handleChange,
+            value: displayVal,
+            inputRef: _inputRef,
+            ...restProps
+          }) => (
             <NumericFormat
               thousandSeparator
               onValueChange={({ value: v }) => handleChange(v)}

--- a/src/components/sharedComponents/BigNumberInput.test.tsx
+++ b/src/components/sharedComponents/BigNumberInput.test.tsx
@@ -146,7 +146,8 @@ describe('BigNumberInput with renderInput (NumericFormat)', () => {
               thousandSeparator
               onValueChange={({ value: v }) => handleChange(v)}
               value={displayVal as string | undefined}
-              {...restProps}
+              // biome-ignore lint/suspicious/noExplicitAny: mirrors TokenAmountField pattern
+              {...(restProps as any)}
             />
           )}
           {...props}

--- a/src/components/sharedComponents/BigNumberInput.test.tsx
+++ b/src/components/sharedComponents/BigNumberInput.test.tsx
@@ -145,7 +145,7 @@ describe('BigNumberInput with renderInput (NumericFormat)', () => {
             <NumericFormat
               thousandSeparator
               onValueChange={({ value: v }) => handleChange(v)}
-              value={displayVal}
+              value={displayVal as string | undefined}
               {...restProps}
             />
           )}

--- a/src/components/sharedComponents/BigNumberInput.test.tsx
+++ b/src/components/sharedComponents/BigNumberInput.test.tsx
@@ -135,10 +135,12 @@ describe('BigNumberInput with renderInput (NumericFormat)', () => {
   ) {
     const onChange = props.onChange ?? vi.fn()
 
-    const makeJsx = (value: bigint) => (
+    const initialDecimals = props.decimals ?? 18
+
+    const makeJsx = (value: bigint, decimals = initialDecimals) => (
       <ChakraProvider value={system}>
         <BigNumberInput
-          decimals={18}
+          decimals={decimals}
           value={value}
           onChange={onChange}
           renderInput={({
@@ -165,7 +167,7 @@ describe('BigNumberInput with renderInput (NumericFormat)', () => {
     return {
       input: container.querySelector('input') as HTMLInputElement,
       onChange,
-      rerender: (newValue: bigint) => rerender(makeJsx(newValue)),
+      rerender: (newValue: bigint, decimals?: number) => rerender(makeJsx(newValue, decimals)),
     }
   }
 
@@ -203,5 +205,18 @@ describe('BigNumberInput with renderInput (NumericFormat)', () => {
   it('shows formatted initial value when mounted with non-zero value', () => {
     const { input } = renderWithNumericFormat({}, parseUnits('1000', 18))
     expect(input.value).toBe('1,000')
+  })
+
+  it('reformats value when decimals change (token switch)', async () => {
+    const value = parseUnits('1000', 18)
+    const { input, rerender } = renderWithNumericFormat({}, value)
+    await waitFor(() => {
+      expect(input.value).toBe('1,000')
+    })
+    // Same bigint but with 6 decimals produces a completely different display value
+    rerender(value, 6)
+    await waitFor(() => {
+      expect(input.value).toBe('1,000,000,000,000,000')
+    })
   })
 })

--- a/src/components/sharedComponents/BigNumberInput.tsx
+++ b/src/components/sharedComponents/BigNumberInput.tsx
@@ -79,7 +79,9 @@ export const BigNumberInput: FC<BigNumberInputProps> = ({
   if (prevValueRef.current !== value || prevDecimalsRef.current !== decimals) {
     prevValueRef.current = value
     prevDecimalsRef.current = decimals
-    setDisplayValue(value === BigInt(0) ? '' : formatUnits(value, decimals))
+    if (renderInput) {
+      setDisplayValue(value === BigInt(0) ? '' : formatUnits(value, decimals))
+    }
   }
 
   // DOM sync for the native input path (no renderInput).

--- a/src/components/sharedComponents/BigNumberInput.tsx
+++ b/src/components/sharedComponents/BigNumberInput.tsx
@@ -120,7 +120,7 @@ export const BigNumberInput: FC<BigNumberInputProps> = ({
 
     if (value === '') {
       prevValueRef.current = BigInt(0)
-      setDisplayValue('')
+      if (renderInput) setDisplayValue('')
       setHasError(false)
       onChange(BigInt(0))
       return
@@ -164,7 +164,7 @@ export const BigNumberInput: FC<BigNumberInputProps> = ({
 
     // Set prevValueRef before onChange so the render-time sync doesn't override the user's input.
     prevValueRef.current = newValue
-    setDisplayValue(value)
+    if (renderInput) setDisplayValue(value)
     onChange(newValue)
   }
 

--- a/src/components/sharedComponents/BigNumberInput.tsx
+++ b/src/components/sharedComponents/BigNumberInput.tsx
@@ -68,8 +68,22 @@ export const BigNumberInput: FC<BigNumberInputProps> = ({
 }: BigNumberInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const [hasError, setHasError] = useState(false)
+  const [displayValue, setDisplayValue] = useState('')
+  const prevValueRef = useRef(value)
+  const prevDecimalsRef = useRef(decimals)
 
-  // update inputValue when value changes
+  // Sync displayValue when an external change updates value or decimals (e.g. max click, token change).
+  // Using render-time state update to avoid a visible flash between renders.
+  if (prevValueRef.current !== value || prevDecimalsRef.current !== decimals) {
+    prevValueRef.current = value
+    prevDecimalsRef.current = decimals
+    setDisplayValue(value === BigInt(0) ? '' : formatUnits(value, decimals))
+  }
+
+  // DOM sync for the native input path (no renderInput).
+  // When renderInput is provided (e.g. NumericFormat), inputRef is not attached to the DOM
+  // and this effect is a no-op. External value changes for that path are handled via
+  // the displayValue state above.
   useEffect(() => {
     const current = inputRef.current
     if (!current) {
@@ -101,6 +115,8 @@ export const BigNumberInput: FC<BigNumberInputProps> = ({
     const { value } = typeof event === 'string' ? { value: event } : event.currentTarget
 
     if (value === '') {
+      prevValueRef.current = BigInt(0)
+      setDisplayValue('')
       setHasError(false)
       onChange(BigInt(0))
       return
@@ -142,6 +158,9 @@ export const BigNumberInput: FC<BigNumberInputProps> = ({
       setHasError(false)
     }
 
+    // Set prevValueRef before onChange so the render-time sync doesn't override the user's input.
+    prevValueRef.current = newValue
+    setDisplayValue(value)
     onChange(newValue)
   }
 
@@ -154,7 +173,7 @@ export const BigNumberInput: FC<BigNumberInputProps> = ({
   }
 
   return renderInput ? (
-    renderInput({ ...inputProps, inputRef })
+    renderInput({ ...inputProps, inputRef, value: displayValue })
   ) : (
     <chakra.input
       {...inputProps}

--- a/src/components/sharedComponents/BigNumberInput.tsx
+++ b/src/components/sharedComponents/BigNumberInput.tsx
@@ -68,7 +68,9 @@ export const BigNumberInput: FC<BigNumberInputProps> = ({
 }: BigNumberInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const [hasError, setHasError] = useState(false)
-  const [displayValue, setDisplayValue] = useState('')
+  const [displayValue, setDisplayValue] = useState(() =>
+    value === BigInt(0) ? '' : formatUnits(value, decimals),
+  )
   const prevValueRef = useRef(value)
   const prevDecimalsRef = useRef(decimals)
 

--- a/src/components/sharedComponents/TokenInput/index.tsx
+++ b/src/components/sharedComponents/TokenInput/index.tsx
@@ -102,6 +102,7 @@ const TokenInput: FC<Props> = ({
   }
 
   const handleSetMax = () => {
+    setAmountError(null)
     setAmount(max)
   }
 


### PR DESCRIPTION
## Summary

Closes #295

When clicking the Max button in `TokenInput`, the value bypassed `NumericFormat`'s formatting
pipeline because `BigNumberInput`'s `inputRef` was not connected to the `NumericFormat`
instance. A `displayValue` state now provides a controlled value string so `NumericFormat`
applies thousand separators on external value changes (max click, token change) as it does
during typing.

## Changes

- Add `displayValue` state to `BigNumberInput` with render-time sync from the `value` prop;
  maps `0n` to `''` to preserve the placeholder
- Update `updateValue` to set `prevValueRef` before `onChange` so user-typed intermediate
  strings (trailing dots, trailing zeros) are not overwritten by the sync
- Pass `value: displayValue` through `renderInputProps` so `NumericFormat` operates in
  controlled mode
- Clear `amountError` in `handleSetMax` to dismiss any prior validation error on max click
- Add 4 tests: empty placeholder on `0n`, thousand-separator formatting on external value
  change, reset to placeholder, user-typed "0" preserved

## Acceptance criteria

- [x] Clicking Max fills the input with the value formatted with thousand separators
- [x] Normal typing and validation continue to work as before
- [x] Placeholder shows when no amount is entered (`0n`)

## Test plan

### Automated tests

Modified: `src/components/sharedComponents/BigNumberInput.test.tsx`

```
pnpm test src/components/sharedComponents/BigNumberInput.test.tsx
```

### Manual verification

1. Open the token input demo
2. Connect a wallet with a token balance > 999
3. Click "Max" — value should appear with thousand separators (e.g. `1,234.56`)
4. Type a value manually — formatting and validation should work as before
5. Clear the input — placeholder `0.00` should reappear

## Breaking changes

None.

## Screenshots

None.

## Checklist

- [x] Self-reviewed my own diff
- [x] Tests added or updated
- [ ] Docs updated (if applicable)
- [x] No unrelated changes bundled in
