### PR TITLE
fix: destructure decimal part in TokenAmountField isAllowed validator

### DIFF
--- a/src/components/sharedComponents/TokenInput/index.tsx
+++ b/src/components/sharedComponents/TokenInput/index.tsx
@@ -228,7 +228,7 @@ function TokenAmountField({
   const { onChange, inputRef, ...restProps } = renderInputProps
 
   const isAllowed = ({ value }: NumberFormatValues) => {
-    const [inputDecimals] = value.toString().split('.')
+    const [, inputDecimals] = value.toString().split('.')
 
     if (!inputDecimals) {
       return true


### PR DESCRIPTION
## Summary

Closes #451

The `isAllowed` validator in `TokenAmountField` was destructuring the integer part (index 0) from `split('.')` instead of the decimal part (index 1). This made the validation compare token decimals against the integer digit count rather than the actual decimal digit count.

## Changes

- Fix destructuring in `isAllowed` to capture the decimal portion (`const [, inputDecimals]`) instead of the integer portion (`const [inputDecimals]`)

## Acceptance criteria

- [x] Variable `inputDecimals` contains the decimal portion of the input value (text after the dot), not the integer portion
- [x] Validation correctly compares token decimal places against the input's decimal digit count

## Test plan

### Automated tests
No automated tests added. The component has no existing test file.

### Manual verification
1. Open a page with `TokenInput`
2. Select a token with limited decimals (e.g., USDC with 6 decimals)
3. Attempt to type a value with more decimal places than allowed
4. Confirm the input rejects excess decimal digits

## Breaking changes

None.

## Screenshots

None.

## Checklist

- [x] Self-reviewed my own diff
- [ ] Tests added or updated
- [x] Docs updated (if applicable)
- [x] No unrelated changes bundled in
