### PR TITLE
fix: use error toast type in watchSignature catch block

### DIFF
--- a/src/providers/TransactionNotificationProvider.tsx
+++ b/src/providers/TransactionNotificationProvider.tsx
@@ -89,7 +89,7 @@ export const TransactionNotificationProvider: FC<PropsWithChildren> = ({ childre
 
       notificationToaster.create({
         description: message,
-        type: 'success',
+        type: 'error',
         id: toastId,
       })
     }


### PR DESCRIPTION
## Summary

Closes #453

The `watchSignature` catch block in `TransactionNotificationProvider` was using `type: 'success'` for error toasts, giving users misleading visual feedback when a signature request fails.

## Changes

- Changed toast notification `type` from `'success'` to `'error'` in the `watchSignature` catch block

## Acceptance criteria

- [x] Failed signature requests show an error-styled toast instead of a success-styled toast

## Test plan

### Automated tests
No automated tests added. The change is a single literal value correction in UI feedback.

### Manual verification
1. Trigger a signature request (e.g., via `SignButton`)
2. Reject or let the signature fail
3. Verify the toast notification uses error styling

## Breaking changes

None.

## Screenshots

None.

## Checklist

- [x] Self-reviewed my own diff
- [ ] Tests added or updated
- [ ] Docs updated (if applicable)
- [x] No unrelated changes bundled in
