### PR TITLE
fix: type WalletStatusVerifier children as ReactNode instead of ReactElement

### DIFF
--- a/src/components/pageComponents/home/Examples/demos/TransactionButton/index.tsx
+++ b/src/components/pageComponents/home/Examples/demos/TransactionButton/index.tsx
@@ -18,21 +18,18 @@ const TransactionButton = () => {
 
   return (
     <WalletStatusVerifier chainId={sepolia.id}>
-      {/* biome-ignore lint/complexity/noUselessFragments: WalletStatusVerifier expects a single ReactElement child */}
-      <>
-        <OptionsDropdown items={items} />
-        <Flex
-          alignItems="center"
-          display="flex"
-          flexDirection="column"
-          justifyContent="center"
-          paddingTop={{ base: 2, lg: 6 }}
-          width="100%"
-        >
-          {currentTokenInput === 'erc20' && <ERC20ApproveAndTransferButton />}
-          {currentTokenInput === 'native' && <NativeToken />}
-        </Flex>
-      </>
+      <OptionsDropdown items={items} />
+      <Flex
+        alignItems="center"
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        paddingTop={{ base: 2, lg: 6 }}
+        width="100%"
+      >
+        {currentTokenInput === 'erc20' && <ERC20ApproveAndTransferButton />}
+        {currentTokenInput === 'native' && <NativeToken />}
+      </Flex>
     </WalletStatusVerifier>
   )
 }

--- a/src/components/sharedComponents/WalletStatusVerifier.tsx
+++ b/src/components/sharedComponents/WalletStatusVerifier.tsx
@@ -1,4 +1,4 @@
-import { createContext, type FC, type ReactElement, useContext } from 'react'
+import { createContext, type FC, type ReactElement, type ReactNode, useContext } from 'react'
 import SwitchChainButton from '@/src/components/sharedComponents/ui/SwitchChainButton'
 import { useWalletStatus } from '@/src/hooks/useWalletStatus'
 import { useWeb3Status, type Web3Status } from '@/src/hooks/useWeb3Status'
@@ -27,7 +27,7 @@ export const useWeb3StatusConnected = () => {
 
 interface WalletStatusVerifierProps {
   chainId?: ChainsIds
-  children?: ReactElement
+  children?: ReactNode
   fallback?: ReactElement
   switchChainLabel?: string
 }


### PR DESCRIPTION
## Summary

Closes #454

The `WalletStatusVerifier` component restricted its `children` prop to `ReactElement`, forcing consumers to wrap multiple children in fragments and suppress lint warnings. Since the component is just a context provider, `ReactNode` is the correct type.

## Changes

- Changed `children` prop type from `ReactElement` to `ReactNode` in `WalletStatusVerifierProps`
- Removed the unnecessary fragment wrapper and its `biome-ignore` lint suppression in the `TransactionButton` demo

## Acceptance criteria

- [x] Change `children?: ReactElement` to `children?: ReactNode` in `WalletStatusVerifierProps`
- [x] Remove any fragment wrappers or lint suppressions that were only needed because of the `ReactElement` constraint
- [x] Existing tests pass

## Test plan

### Automated tests

No new tests added. Existing tests in `src/components/sharedComponents/WalletStatusVerifier.test.tsx` pass (178/178).

```bash
pnpm test
```

### Manual verification

No manual steps required.

## Breaking changes

None.

## Screenshots

None.

## Checklist

- [x] Self-reviewed my own diff
- [ ] Tests added or updated
- [ ] Docs updated (if applicable)
- [x] No unrelated changes bundled in
