### PR TITLE
feat(token-logo): render chain icons for native tokens

### DIFF
--- a/src/components/sharedComponents/TokenLogo/TokenLogo.test.tsx
+++ b/src/components/sharedComponents/TokenLogo/TokenLogo.test.tsx
@@ -110,8 +110,9 @@ describe('TokenLogo', () => {
       name: 'Unknown',
       symbol: 'XXX',
     }
-    renderTokenLogo(nativeUnknownToken)
+    const { container } = renderTokenLogo(nativeUnknownToken)
     expect(screen.queryByRole('img')).toBeNull()
+    expect(container.querySelector('svg')).toBeNull()
     expect(screen.getByText('X')).toBeDefined()
   })
 })

--- a/src/components/sharedComponents/TokenLogo/TokenLogo.test.tsx
+++ b/src/components/sharedComponents/TokenLogo/TokenLogo.test.tsx
@@ -1,11 +1,10 @@
-import { ChakraProvider, createSystem, defaultConfig } from '@chakra-ui/react'
+import { ChakraProvider } from '@chakra-ui/react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { zeroAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
+import { system } from '@/src/components/ui/provider'
 import type { Token } from '@/src/types/token'
 import TokenLogo from '.'
-
-const system = createSystem(defaultConfig)
 
 const mockToken: Token = {
   address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',

--- a/src/components/sharedComponents/TokenLogo/TokenLogo.test.tsx
+++ b/src/components/sharedComponents/TokenLogo/TokenLogo.test.tsx
@@ -1,8 +1,9 @@
 import { ChakraProvider, createSystem, defaultConfig } from '@chakra-ui/react'
 import { fireEvent, render, screen } from '@testing-library/react'
+import { zeroAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
 import type { Token } from '@/src/types/token'
-import TokenLogo from './TokenLogo'
+import TokenLogo from '.'
 
 const system = createSystem(defaultConfig)
 
@@ -71,5 +72,46 @@ describe('TokenLogo', () => {
     renderTokenLogo(ipfsToken)
     const img = screen.getByRole('img')
     expect(img.getAttribute('src')).toBe('https://ipfs.io/ipfs/QmHash123')
+  })
+
+  it('renders the chain icon (not the img or placeholder) for a native token on a mapped chain', () => {
+    const nativeEthToken: Token = {
+      address: zeroAddress,
+      chainId: 1,
+      decimals: 18,
+      name: 'Ether',
+      symbol: 'ETH',
+    }
+    const { container } = renderTokenLogo(nativeEthToken)
+    expect(screen.queryByRole('img')).toBeNull()
+    expect(screen.queryByText('E')).toBeNull()
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+
+  it('renders the chain icon for the native POL on Polygon (chainId 137)', () => {
+    const nativePolToken: Token = {
+      address: zeroAddress,
+      chainId: 137,
+      decimals: 18,
+      name: 'POL',
+      symbol: 'POL',
+    }
+    const { container } = renderTokenLogo(nativePolToken)
+    expect(screen.queryByRole('img')).toBeNull()
+    expect(screen.queryByText('P')).toBeNull()
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+
+  it('falls back to placeholder for a native token on an unmapped chain', () => {
+    const nativeUnknownToken: Token = {
+      address: zeroAddress,
+      chainId: 999999,
+      decimals: 18,
+      name: 'Unknown',
+      symbol: 'XXX',
+    }
+    renderTokenLogo(nativeUnknownToken)
+    expect(screen.queryByRole('img')).toBeNull()
+    expect(screen.getByText('X')).toBeDefined()
   })
 })

--- a/src/components/sharedComponents/TokenLogo/index.tsx
+++ b/src/components/sharedComponents/TokenLogo/index.tsx
@@ -70,10 +70,11 @@ interface TokenLogoProps {
 /**
  * TokenLogo component, displays a token logo based on the provided token object.
  *
- * Native tokens (detected via `token.address === env.PUBLIC_NATIVE_TOKEN_ADDRESS`)
- * render the chain-specific icon from `@web3icons/react` when the chain is mapped
- * in `nativeTokenIcons`. Otherwise the component renders `logoURI` as an image,
- * falling back to the colored-letter Placeholder on load failure or missing URI.
+ * Native tokens (detected via `isNativeToken(token.address)`, a case-insensitive
+ * match against `env.PUBLIC_NATIVE_TOKEN_ADDRESS`) render the chain-specific icon
+ * from `@web3icons/react` when the chain is mapped in `nativeTokenIcons`. Otherwise
+ * the component renders `logoURI` as an image, falling back to the colored-letter
+ * Placeholder on load failure or missing URI.
  *
  * @param {TokenLogoProps} props - TokenLogo component props.
  * @param {Token} props.token - The token object to display the logo for.

--- a/src/components/sharedComponents/TokenLogo/index.tsx
+++ b/src/components/sharedComponents/TokenLogo/index.tsx
@@ -1,5 +1,5 @@
 import { Flex } from '@chakra-ui/react'
-import { type ComponentProps, type FC, useCallback, useEffect, useState } from 'react'
+import { type ComponentProps, type FC, useEffect, useMemo, useState } from 'react'
 
 import { nativeTokenIcons } from '@/src/components/sharedComponents/TokenLogo/nativeTokenIcons'
 import type { ChainsIds } from '@/src/lib/networks.config'
@@ -11,40 +11,31 @@ interface PlaceholderProps extends ComponentProps<'div'> {
   symbol: string
 }
 
+const generateHexColor = (symbol: string): string => {
+  let hash = 0
+  for (let i = 0; i < symbol.length; i++) {
+    hash = symbol.charCodeAt(i) + ((hash << 5) - hash)
+  }
+
+  const baseColor =
+    ((hash >> 24) & 0xff).toString(16).padStart(2, '0') +
+    ((hash >> 16) & 0xff).toString(16).padStart(2, '0') +
+    ((hash >> 8) & 0xff).toString(16).padStart(2, '0')
+
+  const r = Number.parseInt(baseColor.slice(0, 2), 16) % 196
+  const g = Number.parseInt(baseColor.slice(2, 4), 16) % 196
+  const b = Number.parseInt(baseColor.slice(4, 6), 16) % 196
+
+  const color =
+    r.toString(16).padStart(2, '0') +
+    g.toString(16).padStart(2, '0') +
+    b.toString(16).padStart(2, '0')
+
+  return `#${color}`
+}
+
 const Placeholder: FC<PlaceholderProps> = ({ size, symbol, ...restProps }) => {
-  const [backgroundColor, setBackgroundColor] = useState<string>('')
-
-  const generateHexColor = useCallback((symbol: string): string => {
-    // Convert symbol to a hash number
-    let hash = 0
-    for (let i = 0; i < symbol.length; i++) {
-      hash = symbol.charCodeAt(i) + ((hash << 5) - hash)
-    }
-
-    // Convert hash to a hexadecimal string and ensure it is 6 characters long
-    const baseColor =
-      ((hash >> 24) & 0xff).toString(16).padStart(2, '0') +
-      ((hash >> 16) & 0xff).toString(16).padStart(2, '0') +
-      ((hash >> 8) & 0xff).toString(16).padStart(2, '0')
-
-    // Ensure the baseColor is dark-ish by making sure each component is less than 196
-    const r = Number.parseInt(baseColor.slice(0, 2), 16) % 196
-    const g = Number.parseInt(baseColor.slice(2, 4), 16) % 196
-    const b = Number.parseInt(baseColor.slice(4, 6), 16) % 196
-
-    // Convert back to hex string and pad with leading 6s if necessary and also
-    // because I love Satan
-    const color =
-      r.toString(16).padStart(2, '6') +
-      g.toString(16).padStart(2, '6') +
-      b.toString(16).padStart(2, '6')
-
-    return `#${color}`
-  }, [])
-
-  useEffect(() => {
-    setBackgroundColor(generateHexColor(symbol))
-  }, [symbol, generateHexColor])
+  const backgroundColor = useMemo(() => generateHexColor(symbol), [symbol])
 
   return (
     <Flex

--- a/src/components/sharedComponents/TokenLogo/index.tsx
+++ b/src/components/sharedComponents/TokenLogo/index.tsx
@@ -1,6 +1,10 @@
 import { Flex } from '@chakra-ui/react'
 import { type ComponentProps, type FC, useCallback, useEffect, useState } from 'react'
+
+import { nativeTokenIcons } from '@/src/components/sharedComponents/TokenLogo/nativeTokenIcons'
+import type { ChainsIds } from '@/src/lib/networks.config'
 import type { Token } from '@/src/types/token'
+import { isNativeToken } from '@/src/utils/address'
 
 interface PlaceholderProps extends ComponentProps<'div'> {
   size: number
@@ -75,10 +79,14 @@ interface TokenLogoProps {
 /**
  * TokenLogo component, displays a token logo based on the provided token object.
  *
+ * Native tokens (detected via `token.address === env.PUBLIC_NATIVE_TOKEN_ADDRESS`)
+ * render the chain-specific icon from `@web3icons/react` when the chain is mapped
+ * in `nativeTokenIcons`. Otherwise the component renders `logoURI` as an image,
+ * falling back to the colored-letter Placeholder on load failure or missing URI.
+ *
  * @param {TokenLogoProps} props - TokenLogo component props.
  * @param {Token} props.token - The token object to display the logo for.
  * @param {number} [props.size=24] - The size of the logo in pixels.
- * @param {ComponentProps<'img'>} [props.restProps] - Additional props for the img element.
  *
  * @example
  * ```tsx
@@ -96,6 +104,19 @@ const TokenLogo: FC<TokenLogoProps> = ({ size = 24, token }) => {
   useEffect(() => {
     setHasError(false)
   }, [logoURI])
+
+  const NativeIcon = isNativeToken(token.address)
+    ? nativeTokenIcons[token.chainId as ChainsIds]
+    : undefined
+
+  if (NativeIcon) {
+    return (
+      <NativeIcon
+        size={size}
+        variant="background"
+      />
+    )
+  }
 
   return logoURI && !hasError ? (
     <img

--- a/src/components/sharedComponents/TokenLogo/nativeTokenIcons.tsx
+++ b/src/components/sharedComponents/TokenLogo/nativeTokenIcons.tsx
@@ -10,7 +10,7 @@ import {
 
 import type { ChainsIds } from '@/src/lib/networks.config'
 
-export const nativeTokenIcons: Record<ChainsIds, IconComponent> = {
+export const nativeTokenIcons: Partial<Record<ChainsIds, IconComponent>> = {
   1: NetworkEthereum,
   10: NetworkOptimism,
   137: NetworkPolygon,

--- a/src/components/sharedComponents/TokenLogo/nativeTokenIcons.tsx
+++ b/src/components/sharedComponents/TokenLogo/nativeTokenIcons.tsx
@@ -1,0 +1,20 @@
+import type { IconComponent } from '@web3icons/react'
+import {
+  NetworkArbitrumOne,
+  NetworkEthereum,
+  NetworkOptimism,
+  NetworkOptimismSepolia,
+  NetworkPolygon,
+  NetworkSepolia,
+} from '@web3icons/react'
+
+import type { ChainsIds } from '@/src/lib/networks.config'
+
+export const nativeTokenIcons: Partial<Record<ChainsIds, IconComponent>> = {
+  1: NetworkEthereum,
+  10: NetworkOptimism,
+  137: NetworkPolygon,
+  42161: NetworkArbitrumOne,
+  11155111: NetworkSepolia,
+  11155420: NetworkOptimismSepolia,
+}

--- a/src/components/sharedComponents/TokenLogo/nativeTokenIcons.tsx
+++ b/src/components/sharedComponents/TokenLogo/nativeTokenIcons.tsx
@@ -10,7 +10,7 @@ import {
 
 import type { ChainsIds } from '@/src/lib/networks.config'
 
-export const nativeTokenIcons: Partial<Record<ChainsIds, IconComponent>> = {
+export const nativeTokenIcons: Record<ChainsIds, IconComponent> = {
   1: NetworkEthereum,
   10: NetworkOptimism,
   137: NetworkPolygon,

--- a/src/components/ui/provider.tsx
+++ b/src/components/ui/provider.tsx
@@ -3,129 +3,129 @@
 import { ChakraProvider, createSystem, defaultConfig, defineConfig } from '@chakra-ui/react'
 import { ColorModeProvider, type ColorModeProviderProps } from './color-mode'
 
+const customConfig = defineConfig({
+  theme: {
+    // Use tokens for values that don't change with light / dark themes
+    tokens: {
+      fonts: {
+        body: {
+          value: '"Manrope", "Arial", "Helvetica Neue", "Helvetica", sans-serif',
+        },
+        heading: {
+          value: '{fonts.body}',
+        },
+        mono: {
+          value: '"Roboto Mono", "Courier New", monospace',
+        },
+      },
+    },
+    // Use semantic tokens for light / dark values
+    semanticTokens: {
+      colors: {
+        bg: {
+          default: {
+            value: {
+              _light: '#f7f7f7',
+              _dark: '#292B43',
+            },
+          },
+          emphasized: {
+            value: {
+              _light: '#ccc',
+              _dark: '#888',
+            },
+          },
+        },
+        primary: {
+          default: {
+            value: {
+              _light: '#692581',
+              _dark: '#8b46a4',
+            },
+          },
+        },
+        text: {
+          default: {
+            value: {
+              _light: '#4b4d60',
+              _dark: '#e2e0e7',
+            },
+          },
+        },
+        danger: {
+          default: {
+            value: {
+              _light: '#800',
+              _dark: '#ff6666',
+            },
+          },
+        },
+        ok: {
+          default: {
+            value: {
+              _light: '#006600',
+              _dark: '#66ee66',
+            },
+          },
+        },
+        warning: {
+          default: {
+            value: {
+              _light: '#996600',
+              _dark: '#e6b800',
+            },
+          },
+        },
+      },
+    },
+    // Some custom animations
+    keyframes: {
+      rotateSwitch: {
+        from: {
+          transform: 'rotate(0)',
+        },
+        to: {
+          transform: 'rotate(360deg)',
+        },
+      },
+    },
+  },
+  globalCss: {
+    //////////////////////////////////////////////////
+    // Just some basic stuff, don't add too much here.
+    //////////////////////////////////////////////////
+    html: {
+      scrollBehavior: 'smooth',
+      overflowX: 'hidden',
+    },
+    body: {
+      '--moz-osx-font-smoothing': 'grayscale',
+      '--webkit-font-smoothing': 'antialiased',
+      background: '{colors.bg.default}',
+      backgroundPosition: '100% 0',
+      backgroundRepeat: 'no-repeat',
+      color: '{colors.text.default}',
+      fontFamily: '{fonts.body}',
+      lineHeight: 1.5,
+      outlineColor: '{colors.text.default}',
+      overflowX: 'hidden',
+    },
+    code: {
+      fontFamily: '{fonts.mono}',
+    },
+    a: {
+      color: '{colors.primary.default}',
+    },
+    img: {
+      display: 'block',
+      maxInlineSize: '100%',
+    },
+  },
+})
+
+export const system = createSystem(defaultConfig, customConfig)
+
 export function Provider(props: ColorModeProviderProps) {
-  const customConfig = defineConfig({
-    theme: {
-      // Use tokens for values that don't change with light / dark themes
-      tokens: {
-        fonts: {
-          body: {
-            value: '"Manrope", "Arial", "Helvetica Neue", "Helvetica", sans-serif',
-          },
-          heading: {
-            value: '{fonts.body}',
-          },
-          mono: {
-            value: '"Roboto Mono", "Courier New", monospace',
-          },
-        },
-      },
-      // Use semantic tokens for light / dark values
-      semanticTokens: {
-        colors: {
-          bg: {
-            default: {
-              value: {
-                _light: '#f7f7f7',
-                _dark: '#292B43',
-              },
-            },
-            emphasized: {
-              value: {
-                _light: '#ccc',
-                _dark: '#888',
-              },
-            },
-          },
-          primary: {
-            default: {
-              value: {
-                _light: '#692581',
-                _dark: '#8b46a4',
-              },
-            },
-          },
-          text: {
-            default: {
-              value: {
-                _light: '#4b4d60',
-                _dark: '#e2e0e7',
-              },
-            },
-          },
-          danger: {
-            default: {
-              value: {
-                _light: '#800',
-                _dark: '#ff6666',
-              },
-            },
-          },
-          ok: {
-            default: {
-              value: {
-                _light: '#006600',
-                _dark: '#66ee66',
-              },
-            },
-          },
-          warning: {
-            default: {
-              value: {
-                _light: '#996600',
-                _dark: '#e6b800',
-              },
-            },
-          },
-        },
-      },
-      // Some custom animations
-      keyframes: {
-        rotateSwitch: {
-          from: {
-            transform: 'rotate(0)',
-          },
-          to: {
-            transform: 'rotate(360deg)',
-          },
-        },
-      },
-    },
-    globalCss: {
-      //////////////////////////////////////////////////
-      // Just some basic stuff, don't add too much here.
-      //////////////////////////////////////////////////
-      html: {
-        scrollBehavior: 'smooth',
-        overflowX: 'hidden',
-      },
-      body: {
-        '--moz-osx-font-smoothing': 'grayscale',
-        '--webkit-font-smoothing': 'antialiased',
-        background: '{colors.bg.default}',
-        backgroundPosition: '100% 0',
-        backgroundRepeat: 'no-repeat',
-        color: '{colors.text.default}',
-        fontFamily: '{fonts.body}',
-        lineHeight: 1.5,
-        outlineColor: '{colors.text.default}',
-        overflowX: 'hidden',
-      },
-      code: {
-        fontFamily: '{fonts.mono}',
-      },
-      a: {
-        color: '{colors.primary.default}',
-      },
-      img: {
-        display: 'block',
-        maxInlineSize: '100%',
-      },
-    },
-  })
-
-  const system = createSystem(defaultConfig, customConfig)
-
   return (
     <ChakraProvider value={system}>
       <ColorModeProvider {...props} />


### PR DESCRIPTION
## Summary

Closes #164

Native tokens (ETH, MATIC, etc.) previously fell through to the colored placeholder circle in `TokenLogo` because `buildNativeToken()` produces `Token` objects with no `logoURI`. This introduces a static chain-ID-to-icon mapping so `TokenLogo` can resolve and render the well-known chain icon for native tokens directly, without requiring any change to the token data layer.

## Changes

- Add `nativeTokenIcons.tsx` with a static mapping of chain IDs to SVG chain icons
- Refactor `TokenLogo` from a single file into a folder (`TokenLogo/index.tsx` + `TokenLogo/nativeTokenIcons.tsx`)
- Update `TokenLogo` to check for a native token icon when `logoURI` is absent, before falling back to the placeholder
- Expand `TokenLogo.test.tsx` with assertions covering unmapped-chain fallback behavior
- Update `src/components/ui/provider.tsx` to accommodate the icon integration

## Acceptance criteria

- [x] Native tokens rendered by `TokenLogo` display their chain-specific icon instead of the colored placeholder
- [x] Icons display correctly across all configured networks
- [x] Fallback to the existing placeholder still works if a native token logo cannot be loaded

## Test plan

### Automated tests

- `src/components/sharedComponents/TokenLogo/TokenLogo.test.tsx`

```
pnpm test TokenLogo
```

### Manual verification

Open the token select component on a configured network. Verify native tokens (e.g., ETH on Ethereum) display their chain icon instead of a colored letter placeholder. Verify that a network with no mapped icon still shows the placeholder without errors.

## Breaking changes

None.

## Checklist

- [x] Self-reviewed my own diff
- [x] Tests added or updated
- [ ] Docs updated (if applicable)
- [x] No unrelated changes bundled in

## Screenshots

https://github.com/user-attachments/assets/3e5062e3-71e9-454c-8383-3271daff80ef