### PR TITLE
fix(token-lists): drop tokens whose chainId is absent from viem/chains

### DIFF
--- a/src/hooks/useTokenLists.test.ts
+++ b/src/hooks/useTokenLists.test.ts
@@ -222,6 +222,29 @@ describe('useTokenLists', () => {
     expect(nativeToken?.symbol).toBe('ETH')
   })
 
+  it('filters out tokens whose chainId is not present in viem/chains and does not log', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: mocking internal combine param
+    vi.mocked(tanstackQuery.useSuspenseQueries).mockImplementation(({ combine }: any) => {
+      const ropstenToken: Token = {
+        address: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+        chainId: 3,
+        decimals: 18,
+        name: 'Wrapped Ether (Ropsten)',
+        symbol: 'WETH',
+      }
+      return combine([mockSuspenseQueryResult([mockToken1, ropstenToken])])
+    })
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { result } = renderHook(() => useTokenLists(), { wrapper })
+
+    expect(result.current.tokens.some((t) => t.chainId === 3)).toBe(false)
+    expect(result.current.tokensByChainId[3]).toBeUndefined()
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+
   it('filters out tokens that fail schema validation', () => {
     // biome-ignore lint/suspicious/noExplicitAny: mocking internal combine param
     vi.mocked(tanstackQuery.useSuspenseQueries).mockImplementation(({ combine }: any) => {

--- a/src/hooks/useTokenLists.ts
+++ b/src/hooks/useTokenLists.ts
@@ -110,12 +110,14 @@ function combineTokenLists(results: Array<UseSuspenseQueryResult<TokenList>>): T
         .flatMap((result) => result.data.tokens)
         // tokenSchema enforces EVM address format (0x + 40 hex chars), so non-EVM entries
         // (e.g. Solana tokens from @uniswap/default-token-list v18+) are silently dropped here.
+        // Tokens whose chainId is not present in viem/chains (e.g. deprecated testnets like
+        // Ropsten/Rinkeby still shipped by @uniswap/default-token-list) are also dropped so
+        // buildNativeToken never throws and tokensByChainId stays free of unreachable buckets.
         // Supporting non-EVM chains would require changes to the address schema, chain config,
         // wallet integration, and contract lookup -- out of scope for this EVM-focused starter kit.
         .filter((token) => {
-          const result = tokenSchema.safeParse(token)
-
-          return result.success
+          if (!tokenSchema.safeParse(token).success) return false
+          return supportedChainIds.has(token.chainId)
         })
         .map((token) => [tokenKey(token), token]),
     ).values(),
@@ -200,6 +202,8 @@ export async function fetchTokenList(url: string): Promise<TokenList> {
     return emptyTokenList
   }
 }
+
+const supportedChainIds = new Set<number>(Object.values(chains).map((c) => c.id))
 
 /**
  * Builds a native token object based on the chain ID.


### PR DESCRIPTION
## Summary

`@uniswap/default-token-list` 18.13.0 still ships tokens for Ropsten (chainId 3, 4 tokens) and Rinkeby (chainId 4, 227 tokens), both removed from `viem/chains`. `combineTokenLists` caught the `buildNativeToken` throw but logged it via `console.error` before ignoring it, producing `Error: Native token not found for chain ID: 3` and `... chain ID: 4` on every cold load of the home page.

Closes #465

## Changes

- Added a module-scope `supportedChainIds = new Set<number>(Object.values(chains).map((c) => c.id))` in `src/hooks/useTokenLists.ts`, co-located with `buildNativeToken` since both depend on the `viem/chains` import.
- Extended the existing `safeParse` filter to also drop tokens whose `chainId` is not in that set, mirroring the existing non-EVM drop. This removes the throw at source, so the `try/catch` around `buildNativeToken` becomes defensive only, and `tokensByChainId` no longer gets `[3]` / `[4]` buckets populated with unreachable tokens.
- Added a test in `src/hooks/useTokenLists.test.ts` that feeds a Ropsten token (chainId 3) and asserts it is filtered out, no `tokensByChainId[3]` bucket is created, and `console.error` is not called.

## Acceptance criteria

- [x] No `Native token not found` errors logged when loading the app with default config.
- [x] `tokensByChainId` contains only chains supported by `viem/chains`.
- [x] Tests cover the unsupported-chainId case.
- [x] `pnpm lint`, `pnpm test`, `pnpm build` all pass.

## Test plan

- `pnpm lint` — clean.
- `pnpm test` — 199/199 pass across 35 files, 12/12 in `useTokenLists.test.ts` (includes the new case).
- `pnpm build` — succeeds.
- `pnpm tsc --noEmit` — clean (also enforced by the pre-push hook).
- `pnpm dev` — home page loads with no `Native token not found` entries in the devtools console; TokenInput demo continues to render tokens for supported chains.

## Breaking changes

None.

## Checklist

- [x] Self-reviewed my own diff
- [x] Tests added or updated
- [x] Docs updated (if applicable) — no behavior in docs changed
- [x] No unrelated changes bundled in