### PR TITLE
fix(token-lists): drop tokens for chains absent from viem/chains

### DIFF
--- a/src/hooks/useTokenLists.test.ts
+++ b/src/hooks/useTokenLists.test.ts
@@ -222,6 +222,29 @@ describe('useTokenLists', () => {
     expect(nativeToken?.symbol).toBe('ETH')
   })
 
+  it('filters out tokens whose chainId is not present in viem/chains and does not log', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: mocking internal combine param
+    vi.mocked(tanstackQuery.useSuspenseQueries).mockImplementation(({ combine }: any) => {
+      const ropstenToken: Token = {
+        address: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+        chainId: 3,
+        decimals: 18,
+        name: 'Wrapped Ether (Ropsten)',
+        symbol: 'WETH',
+      }
+      return combine([mockSuspenseQueryResult([mockToken1, ropstenToken])])
+    })
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { result } = renderHook(() => useTokenLists(), { wrapper })
+
+    expect(result.current.tokens.some((t) => t.chainId === 3)).toBe(false)
+    expect(result.current.tokensByChainId[3]).toBeUndefined()
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+
   it('filters out tokens that fail schema validation', () => {
     // biome-ignore lint/suspicious/noExplicitAny: mocking internal combine param
     vi.mocked(tanstackQuery.useSuspenseQueries).mockImplementation(({ combine }: any) => {

--- a/src/hooks/useTokenLists.test.ts
+++ b/src/hooks/useTokenLists.test.ts
@@ -241,6 +241,7 @@ describe('useTokenLists', () => {
     expect(result.current.tokens.some((t) => t.chainId === 3)).toBe(false)
     expect(result.current.tokensByChainId[3]).toBeUndefined()
     expect(errorSpy).not.toHaveBeenCalled()
+    expect(result.current.tokens.some((t) => t.address === mockToken1.address)).toBe(true)
 
     errorSpy.mockRestore()
   })

--- a/src/hooks/useTokenLists.ts
+++ b/src/hooks/useTokenLists.ts
@@ -13,6 +13,11 @@ import { type Token, type TokenList, tokenSchema } from '@/src/types/token'
 import { logger } from '@/src/utils/logger'
 import tokenListsCache, { type TokensMap, updateTokenListsCache } from '@/src/utils/tokenListsCache'
 
+const chainsById: Map<number, (typeof chains)[keyof typeof chains]> = new Map()
+for (const chain of Object.values(chains)) {
+  if (!chainsById.has(chain.id)) chainsById.set(chain.id, chain)
+}
+
 /**
  * Loads and processes token lists from configured sources
  *
@@ -122,18 +127,9 @@ function combineTokenLists(results: Array<UseSuspenseQueryResult<TokenList>>): T
   const tokensMap = uniqueTokens.reduce<TokensMap>(
     (acc, token) => {
       if (!acc.tokensByChainId[token.chainId]) {
-        try {
-          // if there's a native token for the chain
-          const nativeToken = buildNativeToken(token.chainId)
-
-          // add it to the list
-          acc.tokensByChainId[token.chainId] = [nativeToken]
-          acc.tokens.push(nativeToken)
-        } catch (err) {
-          console.error(err)
-          // if there's no native token for the chain, ignore the error
-          acc.tokensByChainId[token.chainId] = []
-        }
+        const nativeToken = buildNativeToken(token.chainId)
+        acc.tokensByChainId[token.chainId] = [nativeToken]
+        acc.tokens.push(nativeToken)
       }
 
       acc.tokens.push(token)
@@ -196,10 +192,6 @@ export async function fetchTokenList(url: string): Promise<TokenList> {
     return emptyTokenList
   }
 }
-
-const chainsById: Map<number, (typeof chains)[keyof typeof chains]> = new Map(
-  Object.values(chains).map((c) => [c.id, c]),
-)
 
 /**
  * Builds a native token object based on the chain ID.

--- a/src/hooks/useTokenLists.ts
+++ b/src/hooks/useTokenLists.ts
@@ -197,7 +197,9 @@ export async function fetchTokenList(url: string): Promise<TokenList> {
   }
 }
 
-const chainsById = new Map(Object.values(chains).map((c) => [c.id, c]))
+const chainsById: Map<number, (typeof chains)[keyof typeof chains]> = new Map(
+  Object.values(chains).map((c) => [c.id, c]),
+)
 
 /**
  * Builds a native token object based on the chain ID.

--- a/src/hooks/useTokenLists.ts
+++ b/src/hooks/useTokenLists.ts
@@ -108,17 +108,11 @@ function combineTokenLists(results: Array<UseSuspenseQueryResult<TokenList>>): T
     new Map(
       results
         .flatMap((result) => result.data.tokens)
-        // tokenSchema enforces EVM address format (0x + 40 hex chars), so non-EVM entries
-        // (e.g. Solana tokens from @uniswap/default-token-list v18+) are silently dropped here.
-        // Tokens whose chainId is not present in viem/chains (e.g. deprecated testnets like
-        // Ropsten/Rinkeby still shipped by @uniswap/default-token-list) are also dropped so
-        // buildNativeToken never throws and tokensByChainId stays free of unreachable buckets.
-        // Supporting non-EVM chains would require changes to the address schema, chain config,
-        // wallet integration, and contract lookup -- out of scope for this EVM-focused starter kit.
-        .filter((token) => {
-          if (!tokenSchema.safeParse(token).success) return false
-          return supportedChainIds.has(token.chainId)
-        })
+        // tokenSchema enforces EVM address format, so non-EVM entries (e.g. Solana in
+        // @uniswap/default-token-list v18+) are dropped. Tokens on chainIds absent from
+        // viem/chains are also dropped, so buildNativeToken cannot throw and
+        // tokensByChainId never accumulates unreachable buckets.
+        .filter((token) => tokenSchema.safeParse(token).success && chainsById.has(token.chainId))
         .map((token) => [tokenKey(token), token]),
     ).values(),
   )
@@ -203,7 +197,7 @@ export async function fetchTokenList(url: string): Promise<TokenList> {
   }
 }
 
-const supportedChainIds = new Set<number>(Object.values(chains).map((c) => c.id))
+const chainsById = new Map(Object.values(chains).map((c) => [c.id, c]))
 
 /**
  * Builds a native token object based on the chain ID.
@@ -212,7 +206,7 @@ const supportedChainIds = new Set<number>(Object.values(chains).map((c) => c.id)
  * @returns The native token object.
  */
 function buildNativeToken(chainId: Token['chainId']): Token {
-  const tokenInfo = Object.values(chains).find((chain) => chain.id === chainId)?.nativeCurrency
+  const tokenInfo = chainsById.get(chainId)?.nativeCurrency
 
   if (!tokenInfo) {
     throw new Error(`Native token not found for chain ID: ${chainId}`)

--- a/src/hooks/useTokenLists.ts
+++ b/src/hooks/useTokenLists.ts
@@ -110,12 +110,14 @@ function combineTokenLists(results: Array<UseSuspenseQueryResult<TokenList>>): T
         .flatMap((result) => result.data.tokens)
         // tokenSchema enforces EVM address format (0x + 40 hex chars), so non-EVM entries
         // (e.g. Solana tokens from @uniswap/default-token-list v18+) are silently dropped here.
+        // Tokens whose chainId is not present in viem/chains (e.g. deprecated testnets like
+        // Ropsten/Rinkeby still shipped by @uniswap/default-token-list) are also dropped so
+        // buildNativeToken never throws and tokensByChainId stays free of unreachable buckets.
         // Supporting non-EVM chains would require changes to the address schema, chain config,
         // wallet integration, and contract lookup -- out of scope for this EVM-focused starter kit.
         .filter((token) => {
-          const result = tokenSchema.safeParse(token)
-
-          return result.success
+          if (!tokenSchema.safeParse(token).success) return false
+          return supportedChainIds.has(token.chainId)
         })
         .map((token) => [tokenKey(token), token]),
     ).values(),
@@ -200,6 +202,8 @@ export async function fetchTokenList(url: string): Promise<TokenList> {
     return emptyTokenList
   }
 }
+
+const supportedChainIds = new Set<number>(Object.values(chains).map((c) => c.id))
 
 /**
  * Builds a native token object based on the chain ID.


### PR DESCRIPTION
## Summary

Closes #465

`@uniswap/default-token-list` still ships tokens for deprecated testnets (Ropsten chain ID 3, Rinkeby chain ID 4) that `viem/chains` no longer exports. On every cold load, `combineTokenLists` caught the `buildNativeToken` throw and emitted it via `console.error` -- noise despite the intent to ignore it. This implements Option B from the issue: filter out tokens whose `chainId` is absent from `viem/chains` before they reach `buildNativeToken`, eliminating the errors at source and keeping `tokensByChainId` free of unreachable chain buckets.

## Changes

- Filter tokens with unsupported `chainId` values out of combined token lists before building native tokens
- Replace the `supportedChainIds` Set with a shared `chainsById` Map for O(1) lookups and reuse across the pipeline
- Annotate the `chainsById` Map key as `number` to satisfy tsc
- Preserve first-wins semantics in `chainsById` population and drop the now-dead catch block

## Acceptance criteria

- [x] No `Native token not found` errors logged when loading the app with default config
- [x] `tokensByChainId` contains only chains supported by `viem/chains`
- [x] Tests cover the unsupported-chainId case
- [ ] `pnpm lint`, `pnpm test`, `pnpm build` all pass

## Test plan

##### Automated tests
`src/hooks/useTokenLists.test.ts` -- updated with coverage for the unsupported-chainId filter case.

Run: `pnpm test src/hooks/useTokenLists.test.ts`

##### Manual verification
1. `pnpm dev`
2. Open the home page (TokenInput demo calls `useTokenLists`)
3. Open browser devtools console
4. Verify no `Native token not found for chain ID: 3` or `... chain ID: 4` errors appear on cold load

## Breaking changes

None.

## Checklist

- [x] Self-reviewed my own diff
- [x] Tests added or updated
- [ ] Docs updated (if applicable)
- [x] No unrelated changes bundled in

## Screenshots

None.
