### PR TITLE
fix: pair logger.timeEnd for 'updating tokens cache' in useTokens

### DIFF
--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -226,6 +226,7 @@ export function updateTokensBalances(
     },
     {} as TokensMap['tokensByChainId'],
   )
+  logger.timeEnd('updating tokens cache')
 
   return { tokens: tokensWithBalances, tokensByChainId: tokensByChain }
 }


### PR DESCRIPTION
## Summary

Closes #467

The `updateTokensBalances` function in `src/hooks/useTokens.ts` started a `logger.time('updating tokens cache')` timer but never called the matching `logger.timeEnd`, so every recompute of the wrapping `useMemo` re-started the timer and triggered `Timer 'updating tokens cache' already exists` warnings in the dev console. Dev-only noise, but drowns useful logs.

## Changes

- Add matching `logger.timeEnd('updating tokens cache')` call before the `return` in `updateTokensBalances` (`src/hooks/useTokens.ts:229`)

## Acceptance criteria

- [ ] No `Timer ... already exists` warnings when opening the token selector and triggering re-renders
- [x] All three `logger.time` calls in `updateTokensBalances` have matching `logger.timeEnd` calls
- [ ] The `updating tokens cache` timing is visible in the dev console like the other two

## Test plan

### Automated tests

No automated tests added -- dev-only `logger` timing is gated by `isDev` and not covered by existing tests. `pnpm test` still passes (198 tests).

### Manual verification

1. `pnpm dev` with a connected wallet
2. Open any page that uses the token selector / `useTokens` with `withBalance=true`
3. Open the selector and interact so the consuming component re-renders a few times
4. Confirm no `Timer 'updating tokens cache' already exists` warnings in the console
5. Confirm the `updating tokens cache: <time>` line prints alongside `extending tokens with balance info` and `sorting tokens by balance`

## Breaking changes

None.

## Checklist

- [x] Self-reviewed my own diff
- [ ] Tests added or updated
- [ ] Docs updated (if applicable)
- [x] No unrelated changes bundled in

## Screenshots

None.
