### PR TITLE
fix(use-tokens): route LI.FI RPC calls through configured transports

### DIFF
--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -14,6 +14,7 @@ import { type Address, type Chain, formatUnits } from 'viem'
 import { env } from '@/src/env'
 import { useTokenLists } from '@/src/hooks/useTokenLists'
 import { useWeb3Status } from '@/src/hooks/useWeb3Status'
+import { rpcUrls } from '@/src/lib/networks.config'
 import type { Token, Tokens } from '@/src/types/token'
 import { toLocalNativeAddress } from '@/src/utils/address'
 import { logger } from '@/src/utils/logger'
@@ -25,6 +26,9 @@ const BALANCE_EXPIRATION_TIME = 32_000
 export const lifiConfig = createConfig({
   integrator: env.PUBLIC_APP_NAME,
   providers: [EVM()],
+  rpcUrls: Object.fromEntries(
+    Object.entries(rpcUrls).map(([chainId, url]) => [Number(chainId), [url]]),
+  ),
 })
 
 /**

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -14,7 +14,7 @@ import { type Address, type Chain, formatUnits } from 'viem'
 import { env } from '@/src/env'
 import { useTokenLists } from '@/src/hooks/useTokenLists'
 import { useWeb3Status } from '@/src/hooks/useWeb3Status'
-import { rpcUrls } from '@/src/lib/networks.config'
+import { lifiRpcUrls } from '@/src/lib/networks.config'
 import type { Token, Tokens } from '@/src/types/token'
 import { toLocalNativeAddress } from '@/src/utils/address'
 import { logger } from '@/src/utils/logger'
@@ -26,9 +26,7 @@ const BALANCE_EXPIRATION_TIME = 32_000
 export const lifiConfig = createConfig({
   integrator: env.PUBLIC_APP_NAME,
   providers: [EVM()],
-  rpcUrls: Object.fromEntries(
-    Object.entries(rpcUrls).map(([chainId, url]) => [Number(chainId), [url]]),
-  ),
+  rpcUrls: lifiRpcUrls,
 })
 
 /**

--- a/src/lib/networks.config.test.ts
+++ b/src/lib/networks.config.test.ts
@@ -1,0 +1,77 @@
+import { arbitrum, mainnet, optimism, optimismSepolia, polygon, sepolia } from 'viem/chains'
+import { describe, expect, it, vi } from 'vitest'
+
+const CUSTOM_ARBITRUM_RPC = 'https://custom.example/arbitrum'
+
+vi.mock('@/src/env', () => ({
+  env: {
+    PUBLIC_APP_NAME: 'test',
+    PUBLIC_INCLUDE_TESTNETS: true,
+    PUBLIC_RPC_ARBITRUM: CUSTOM_ARBITRUM_RPC,
+  },
+}))
+
+vi.mock('@/src/constants/common', () => ({
+  includeTestnets: true,
+}))
+
+const { chains, rpcUrls, lifiRpcUrls } = await import('@/src/lib/networks.config')
+
+const ALL_CHAIN_IDS = [
+  mainnet.id,
+  arbitrum.id,
+  optimism.id,
+  optimismSepolia.id,
+  polygon.id,
+  sepolia.id,
+]
+
+describe('rpcUrls', () => {
+  it('covers every configured chain', () => {
+    for (const id of ALL_CHAIN_IDS) {
+      expect(rpcUrls).toHaveProperty(String(id))
+      expect(typeof rpcUrls[id as keyof typeof rpcUrls]).toBe('string')
+      expect(rpcUrls[id as keyof typeof rpcUrls].length).toBeGreaterThan(0)
+    }
+  })
+
+  it('uses the env-supplied URL when set', () => {
+    expect(rpcUrls[arbitrum.id]).toBe(CUSTOM_ARBITRUM_RPC)
+  })
+
+  it('falls back to publicnode.com when env var is absent', () => {
+    expect(rpcUrls[mainnet.id]).toContain('publicnode.com')
+    expect(rpcUrls[optimism.id]).toContain('publicnode.com')
+    expect(rpcUrls[polygon.id]).toContain('publicnode.com')
+  })
+})
+
+describe('lifiRpcUrls', () => {
+  it('covers the same chain IDs as rpcUrls', () => {
+    const rpcKeys = Object.keys(rpcUrls).map(Number).sort()
+    const lifiKeys = Object.keys(lifiRpcUrls).map(Number).sort()
+    expect(lifiKeys).toEqual(rpcKeys)
+  })
+
+  it('wraps each rpcUrls value in a single-element array', () => {
+    for (const id of ALL_CHAIN_IDS) {
+      const lifiEntry = lifiRpcUrls[id as keyof typeof lifiRpcUrls]
+      expect(Array.isArray(lifiEntry)).toBe(true)
+      expect(lifiEntry).toHaveLength(1)
+      expect(lifiEntry[0]).toBe(rpcUrls[id as keyof typeof rpcUrls])
+    }
+  })
+
+  it('propagates the env-supplied URL', () => {
+    expect(lifiRpcUrls[arbitrum.id]).toEqual([CUSTOM_ARBITRUM_RPC])
+  })
+})
+
+describe('chains', () => {
+  it('contains all chain IDs covered by rpcUrls when testnets enabled', () => {
+    const chainIds = chains.map((c) => c.id)
+    for (const id of ALL_CHAIN_IDS) {
+      expect(chainIds).toContain(id)
+    }
+  })
+})

--- a/src/lib/networks.config.ts
+++ b/src/lib/networks.config.ts
@@ -16,14 +16,22 @@ const allChains = [...devChains, ...prodChains] as const
 export const chains = includeTestnets ? allChains : prodChains
 export type ChainsIds = (typeof chains)[number]['id']
 
+export const rpcUrls = {
+  [mainnet.id]: env.PUBLIC_RPC_MAINNET || 'https://ethereum-rpc.publicnode.com',
+  [arbitrum.id]: env.PUBLIC_RPC_ARBITRUM || 'https://arbitrum-one-rpc.publicnode.com',
+  [optimism.id]: env.PUBLIC_RPC_OPTIMISM || 'https://optimism-rpc.publicnode.com',
+  [optimismSepolia.id]:
+    env.PUBLIC_RPC_OPTIMISM_SEPOLIA || 'https://optimism-sepolia-rpc.publicnode.com',
+  [polygon.id]: env.PUBLIC_RPC_POLYGON || 'https://polygon-bor-rpc.publicnode.com',
+  [sepolia.id]: env.PUBLIC_RPC_SEPOLIA || 'https://ethereum-sepolia-rpc.publicnode.com',
+} as const satisfies Record<ChainsIds, string>
+
 type RestrictedTransports = Record<ChainsIds, Transport>
 export const transports: RestrictedTransports = {
-  [mainnet.id]: http(env.PUBLIC_RPC_MAINNET || 'https://ethereum-rpc.publicnode.com'),
-  [arbitrum.id]: http(env.PUBLIC_RPC_ARBITRUM || 'https://arbitrum-one-rpc.publicnode.com'),
-  [optimism.id]: http(env.PUBLIC_RPC_OPTIMISM || 'https://optimism-rpc.publicnode.com'),
-  [optimismSepolia.id]: http(
-    env.PUBLIC_RPC_OPTIMISM_SEPOLIA || 'https://optimism-sepolia-rpc.publicnode.com',
-  ),
-  [polygon.id]: http(env.PUBLIC_RPC_POLYGON || 'https://polygon-bor-rpc.publicnode.com'),
-  [sepolia.id]: http(env.PUBLIC_RPC_SEPOLIA || 'https://ethereum-sepolia-rpc.publicnode.com'),
+  [mainnet.id]: http(rpcUrls[mainnet.id]),
+  [arbitrum.id]: http(rpcUrls[arbitrum.id]),
+  [optimism.id]: http(rpcUrls[optimism.id]),
+  [optimismSepolia.id]: http(rpcUrls[optimismSepolia.id]),
+  [polygon.id]: http(rpcUrls[polygon.id]),
+  [sepolia.id]: http(rpcUrls[sepolia.id]),
 }

--- a/src/lib/networks.config.ts
+++ b/src/lib/networks.config.ts
@@ -26,6 +26,16 @@ export const rpcUrls = {
   [sepolia.id]: env.PUBLIC_RPC_SEPOLIA || 'https://ethereum-sepolia-rpc.publicnode.com',
 } as const satisfies Record<ChainsIds, string>
 
+/** RPC URL map in the shape expected by LI.FI's `createConfig({ rpcUrls })`. */
+export const lifiRpcUrls: Record<ChainsIds, string[]> = {
+  [mainnet.id]: [rpcUrls[mainnet.id]],
+  [arbitrum.id]: [rpcUrls[arbitrum.id]],
+  [optimism.id]: [rpcUrls[optimism.id]],
+  [optimismSepolia.id]: [rpcUrls[optimismSepolia.id]],
+  [polygon.id]: [rpcUrls[polygon.id]],
+  [sepolia.id]: [rpcUrls[sepolia.id]],
+}
+
 type RestrictedTransports = Record<ChainsIds, Transport>
 export const transports: RestrictedTransports = {
   [mainnet.id]: http(rpcUrls[mainnet.id]),


### PR DESCRIPTION
## Summary

Closes #469

LI.FI's `EVM()` provider was initialized without explicit RPC configuration, causing it to fall back to hardcoded default URLs (e.g., `arb1.arbitrum.io` for Arbitrum). Those defaults hit CORS restrictions and rate limits in dev. This fix routes LI.FI's RPC calls through the same URLs already used by viem/wagmi transports.

## Changes

- Extract RPC URL strings from `transports` into a shared `rpcUrls` map exported from `networks.config.ts`
- Pass `rpcUrls` to LI.FI's `createConfig` so the SDK uses project-configured endpoints instead of its bundled defaults
- Refactor `transports` to derive from `rpcUrls`, eliminating duplication

## Acceptance criteria

- [x] Selecting Arbitrum in `TokenSelect` no longer produces CORS errors or 429s from `arb1.arbitrum.io`
- [x] Token balances load on Arbitrum using the publicnode RPC fallback configured in `networks.config.ts`
- [x] Other chains continue to work correctly

## Test plan

##### Automated tests

`src/lib/networks.config.test.ts` — run with `pnpm test`

##### Manual verification

1. Run `pnpm dev`
2. Open a page with `TokenSelect` (e.g. the `TokenInput` demo)
3. Switch to Arbitrum in the network dropdown
4. Confirm no CORS or 429 errors from `arb1.arbitrum.io` in the console
5. Confirm token balances load

## Breaking changes

None.

## Checklist

- [x] Self-reviewed my own diff
- [x] Tests added or updated
- [ ] Docs updated (if applicable)
- [x] No unrelated changes bundled in

## Screenshots

None.
