### PR TITLE
fix(header): remove fixed height from logo to preserve aspect ratio

### DIFF
--- a/src/components/sharedComponents/ui/Header/Logo.tsx
+++ b/src/components/sharedComponents/ui/Header/Logo.tsx
@@ -15,7 +15,6 @@ const LogoLight =
 const Logo: FC<ImageProps> = ({ ...restProps }) => (
   <chakra.img
     width={193}
-    height={77}
     content="var(--base-logo)"
     display="block"
     flexShrink="0"


### PR DESCRIPTION
## Summary

Closes #476

Both `width` and `height` were fixed on the logo element, which forces
a specific aspect ratio regardless of the image's natural dimensions.
Removing the fixed height lets the browser derive it from the SVG's
intrinsic size, so the logo always renders proportionally.

## Changes

- Remove `height={77}` from `chakra.img` in `Logo.tsx`; height is now
  derived from the image's intrinsic dimensions while `width={193}`
  continues to control the render size

## Acceptance criteria

- [x] Logo renders at its natural aspect ratio when displayed in the header

## Test plan

### Automated tests

No automated tests added or modified — this is a single-prop removal
with no logic change.

Run: `pnpm test`

### Manual verification

1. Load the application
2. Observe the logo in the header — it should render without stretching

## Breaking changes

None.

## Checklist

- [x] Self-reviewed my own diff
- [x] Tests added or updated
- [ ] Docs updated (if applicable)
- [x] No unrelated changes bundled in

## Screenshots

None.
