### PR TITLE
release: merge v2.5.0 back into develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dappbooster",
   "private": true,
-  "version": "2.0.4",
+  "version": "2.5.0",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit --pretty && vite build",


### PR DESCRIPTION
## Summary

No related issue. Back-merge the v2.5.0 release branch into develop to keep the version bump in sync.

Standard git-flow step: brings the `release: bump version to 2.5.0` commit from release/v2.5.0 back into develop so both long-lived branches stay at 2.5.0.

## Changes

- release: bump version to 2.5.0 in package.json

## Acceptance criteria

- [ ] package.json version in develop reads 2.5.0 after merge

## Test plan

### Automated tests

No new tests — this is a version bump only.

### Manual verification

No manual steps required.

## Breaking changes

None.

## Checklist

- [x] Self-reviewed my own diff
- [x] Tests added or updated
- [x] Docs updated (if applicable)
- [x] No unrelated changes bundled in

## Screenshots

None.
